### PR TITLE
Support for multiple registries with pull and search commands

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -284,7 +284,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 
 // 'docker login': login / register a user to registry service.
 func (cli *DockerCli) CmdLogin(args ...string) error {
-	cmd := cli.Subcmd("login", "[SERVER]", "Register or log in to a Docker registry server, if no server is specified \""+registry.IndexServerAddress()+"\" is the default.", true)
+	cmd := cli.Subcmd("login", "[SERVER]", "Register or log in to a Docker registry server, if no server is specified \""+registry.IndexServerAddress("")+"\" is the default.", true)
 	cmd.Require(flag.Max, 1)
 
 	var username, password, email string
@@ -295,7 +295,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 
 	utils.ParseFlags(cmd, args, true)
 
-	serverAddress := registry.IndexServerAddress()
+	serverAddress := registry.IndexServerAddress("")
 	if len(cmd.Args()) > 0 {
 		serverAddress = cmd.Arg(0)
 	}
@@ -400,11 +400,11 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 
 // log out from a Docker registry
 func (cli *DockerCli) CmdLogout(args ...string) error {
-	cmd := cli.Subcmd("logout", "[SERVER]", "Log out from a Docker registry, if no server is specified \""+registry.IndexServerAddress()+"\" is the default.", true)
+	cmd := cli.Subcmd("logout", "[SERVER]", "Log out from a Docker registry, if no server is specified \""+registry.IndexServerAddress("")+"\" is the default.", true)
 	cmd.Require(flag.Max, 1)
 
 	utils.ParseFlags(cmd, args, false)
-	serverAddress := registry.IndexServerAddress()
+	serverAddress := registry.IndexServerAddress("")
 	if len(cmd.Args()) > 0 {
 		serverAddress = cmd.Arg(0)
 	}

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -66,7 +66,7 @@ func (cli *DockerCli) call(method, path string, data interface{}, passAuthInfo b
 	if passAuthInfo {
 		cli.LoadConfigFile()
 		// Resolve the Auth config relevant for this server
-		authConfig := cli.configFile.Configs[registry.IndexServerAddress()]
+		authConfig := cli.configFile.Configs[registry.IndexServerAddress("")]
 		getHeaders := func(authConfig registry.AuthConfig) (map[string][]string, error) {
 			buf, err := json.Marshal(authConfig)
 			if err != nil {

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -80,7 +80,7 @@ func (daemon *Daemon) CmdInfo(job *engine.Job) engine.Status {
 	v.SetInt("NEventsListener", env.GetInt("count"))
 	v.Set("KernelVersion", kernelVersion)
 	v.Set("OperatingSystem", operatingSystem)
-	v.Set("IndexServerAddress", registry.IndexServerAddress())
+	v.Set("IndexServerAddress", registry.IndexServerAddress(""))
 	v.SetJson("RegistryConfig", registryConfig)
 	v.Set("InitSha1", dockerversion.INITSHA1)
 	v.Set("InitPath", initPath)

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -45,7 +45,9 @@ func main() {
 	if *flAppendRegistry != "" {
 		regs := strings.Split(*flAppendRegistry, ",")
 		for r := range regs {
-			registry.RegistryList = append(registry.RegistryList, regs[r])
+			// TODO: we actually prepend here - reflect this in the option name
+			// (--registry-prepend)
+			registry.RegistryList = append([]string{regs[r]}, registry.RegistryList...)
 		}
 	}
 

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -20,11 +20,18 @@ import (
 
 func (s *TagStore) CmdRegistryPull(job *engine.Job) engine.Status {
 	var (
-		tmp    = job.Args[0]
-		status = engine.StatusErr
+		tmp        = job.Args[0]
+		status     = engine.StatusErr
+		registries = registry.RegistryList
 	)
-	for _, r := range registry.RegistryList {
-		if r != registry.INDEXNAME {
+	// Unless the index name is specified, iterate over all registries until
+	// the matching image is found.
+	if registry.RepositoryNameHasIndex(tmp) {
+		registries = []string{""}
+	}
+	for i, r := range registries {
+		if i > 0 {
+			// Prepend the index name to the image/repository.
 			job.Args[0] = fmt.Sprintf("%s/%s", r, tmp)
 		} else {
 			job.Args[0] = tmp

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -182,9 +182,9 @@ func LoadConfig(rootPath string) (*ConfigFile, error) {
 			return &configFile, fmt.Errorf("Invalid Auth config file")
 		}
 		authConfig.Email = origEmail[1]
-		authConfig.ServerAddress = IndexServerAddress()
+		authConfig.ServerAddress = IndexServerAddress("")
 		// *TODO: Switch to using IndexServerName() instead?
-		configFile.Configs[IndexServerAddress()] = authConfig
+		configFile.Configs[IndexServerAddress("")] = authConfig
 	} else {
 		for k, authConfig := range configFile.Configs {
 			authConfig.Username, authConfig.Password, err = decodeAuth(authConfig.Auth)
@@ -262,7 +262,7 @@ func loginV1(authConfig *AuthConfig, registryEndpoint *Endpoint, factory *utils.
 		return "", fmt.Errorf("Server Error: Server Address not set.")
 	}
 
-	loginAgainstOfficialIndex := serverAddress == IndexServerAddress()
+	loginAgainstOfficialIndex := serverAddress == INDEXSERVER
 
 	// to avoid sending the server address to the server it should be removed before being marshalled
 	authCopy := *authConfig

--- a/registry/auth_test.go
+++ b/registry/auth_test.go
@@ -36,7 +36,7 @@ func setupTempConfigFile() (*ConfigFile, error) {
 		Configs:  make(map[string]AuthConfig),
 	}
 
-	for _, registry := range []string{"testIndex", IndexServerAddress()} {
+	for _, registry := range []string{"testIndex", IndexServerAddress("")} {
 		configFile.Configs[registry] = AuthConfig{
 			Username: "docker-user",
 			Password: "docker-pass",
@@ -81,7 +81,7 @@ func TestResolveAuthConfigIndexServer(t *testing.T) {
 	}
 	defer os.RemoveAll(configFile.rootPath)
 
-	indexConfig := configFile.Configs[IndexServerAddress()]
+	indexConfig := configFile.Configs[IndexServerAddress("")]
 
 	officialIndex := &IndexInfo{
 		Official: true,
@@ -119,7 +119,7 @@ func TestResolveAuthConfigFullURL(t *testing.T) {
 		Password: "baz-pass",
 		Email:    "baz@example.com",
 	}
-	configFile.Configs[IndexServerAddress()] = officialAuth
+	configFile.Configs[IndexServerAddress("")] = officialAuth
 
 	expectedAuths := map[string]AuthConfig{
 		"registry.example.com": registryAuth,

--- a/registry/config.go
+++ b/registry/config.go
@@ -24,7 +24,8 @@ const (
 	// Only used for user auth + account creation
 	INDEXSERVER    = "https://index.docker.io/v1/"
 	REGISTRYSERVER = "https://registry-1.docker.io/v2/"
-	INDEXNAME      = "docker.io"
+	// The name of official index.
+	INDEXNAME = "docker.io"
 
 	// INDEXSERVER = "https://registry-stage.hub.docker.com/v1/"
 )
@@ -36,16 +37,33 @@ var (
 	validRepo                = regexp.MustCompile(`^([a-z0-9-_.]+)$`)
 )
 
-func IndexServerAddress() string {
-	if RegistryList[0] == INDEXNAME {
+// IndexServerName returns the name of default index server.
+func IndexServerName() string {
+	return RegistryList[0]
+}
+
+// IndexServerAddress returns an index uri for given name. Empty string is
+// treated the same as a result of IndexServerName().
+func IndexServerAddress(indexName string) string {
+	if (indexName == "" && RegistryList[0] == INDEXNAME) || indexName == INDEXNAME || indexName == INDEXSERVER {
 		return INDEXSERVER
+	} else if indexName != "" {
+		return fmt.Sprintf("http://%s/v1/", indexName)
 	} else {
-		return "http://" + RegistryList[0] + "/v1/"
+		return fmt.Sprintf("http://%s/v1/", RegistryList[0])
 	}
 }
 
-func IndexServerName() string {
-	return RegistryList[0]
+// RegistryServerAddress returns a registry uri for given index name. Empty string
+// is treated the same as a result of IndexServerName().
+func RegistryServerAddress(indexName string) string {
+	if (indexName == "" && RegistryList[0] == INDEXNAME) || indexName == INDEXNAME {
+		return REGISTRYSERVER
+	} else if indexName != "" {
+		return fmt.Sprintf("http://%s/v2/", indexName)
+	} else {
+		return fmt.Sprintf("http://%s/v2/", RegistryList[0])
+	}
 }
 
 // InstallFlags adds command-line options to the top-level flag parser for
@@ -123,8 +141,8 @@ func NewServiceConfig(options *Options) *ServiceConfig {
 		config.IndexConfigs[IndexServerName()] = &IndexInfo{
 			Name:     IndexServerName(),
 			Mirrors:  options.Mirrors.GetAll(),
-			Secure:   true,
-			Official: true,
+			Secure:   IndexServerName() == INDEXNAME,
+			Official: IndexServerName() == INDEXNAME,
 		}
 	}
 
@@ -258,11 +276,18 @@ func ValidateRepositoryName(reposName string) error {
 	if err = validateNoSchema(reposName); err != nil {
 		return err
 	}
-	indexName, remoteName := splitReposName(reposName)
+	indexName, remoteName := splitReposName(reposName, true)
 	if _, err = ValidateIndexName(indexName); err != nil {
 		return err
 	}
 	return validateRemoteName(remoteName)
+}
+
+// RepositoryNameHasIndex determines whether the given reposName has prepended
+// name of index.
+func RepositoryNameHasIndex(reposName string) bool {
+	indexName, _ := splitReposName(reposName, false)
+	return indexName != ""
 }
 
 // NewIndexInfo returns IndexInfo configuration from indexName
@@ -282,7 +307,7 @@ func (config *ServiceConfig) NewIndexInfo(indexName string) (*IndexInfo, error) 
 	index := &IndexInfo{
 		Name:     indexName,
 		Mirrors:  make([]string, 0),
-		Official: false,
+		Official: indexName == INDEXNAME,
 	}
 	index.Secure = config.isSecureIndex(indexName)
 	return index, nil
@@ -292,20 +317,24 @@ func (config *ServiceConfig) NewIndexInfo(indexName string) (*IndexInfo, error) 
 // index as the AuthConfig key, and uses the (host)name[:port] for private indexes.
 func (index *IndexInfo) GetAuthConfigKey() string {
 	if index.Official {
-		return IndexServerAddress()
+		return INDEXSERVER
 	}
 	return index.Name
 }
 
 // splitReposName breaks a reposName into an index name and remote name
-func splitReposName(reposName string) (string, string) {
+// fixMissingIndex says to return current index server name if missing in
+// reposName
+func splitReposName(reposName string, fixMissingIndex bool) (string, string) {
 	nameParts := strings.SplitN(reposName, "/", 2)
 	var indexName, remoteName string
 	if len(nameParts) == 1 || (!strings.Contains(nameParts[0], ".") &&
 		!strings.Contains(nameParts[0], ":") && nameParts[0] != "localhost") {
 		// This is a Docker Index repos (ex: samalba/hipache or ubuntu)
 		// 'docker.io'
-		indexName = IndexServerName()
+		if fixMissingIndex {
+			indexName = IndexServerName()
+		}
 		remoteName = reposName
 	} else {
 		indexName = nameParts[0]
@@ -320,7 +349,7 @@ func (config *ServiceConfig) NewRepositoryInfo(reposName string) (*RepositoryInf
 		return nil, err
 	}
 
-	indexName, remoteName := splitReposName(reposName)
+	indexName, remoteName := splitReposName(reposName, true)
 	if err := validateRemoteName(remoteName); err != nil {
 		return nil, err
 	}

--- a/registry/endpoint.go
+++ b/registry/endpoint.go
@@ -22,6 +22,8 @@ func scanForAPIVersion(address string) (string, APIVersion) {
 		chunks        []string
 		apiVersionStr string
 	)
+	log.Debugf("endpoint.scanForAPIVersion: starting with address=%s", address)
+	defer log.Debugf("endpoint.scanForAPIVersion: terminating")
 
 	if strings.HasSuffix(address, "/") {
 		address = address[:len(address)-1]
@@ -43,6 +45,8 @@ func scanForAPIVersion(address string) (string, APIVersion) {
 // NewEndpoint parses the given address to return a registry endpoint.
 func NewEndpoint(index *IndexInfo) (*Endpoint, error) {
 	// *TODO: Allow per-registry configuration of endpoints.
+	log.Debugf("endpoint.NewEndpoint: starting with index=%v", index)
+	defer log.Debugf("endpoint.NewEndpoint: terminating")
 	endpoint, err := newEndpoint(index.GetAuthConfigKey(), index.Secure)
 	if err != nil {
 		return nil, err
@@ -87,13 +91,21 @@ func newEndpoint(address string, secure bool) (*Endpoint, error) {
 		trimmedAddress string
 		err            error
 	)
+	fmt.Printf("endpoint.newEndpoint: starting with address=%s, secure=%t\n", address, secure)
+	defer fmt.Printf("endpoint.newEndpoint: terminating\n")
 
 	if !strings.HasPrefix(address, "http") {
-		address = "https://" + address
+		if secure {
+			address = "https://" + address
+		} else {
+			address = "http://" + address
+		}
 	}
 
+	fmt.Printf("endpoint.newEndpoint: address after prefixing: %s\n", address)
 	trimmedAddress, endpoint.Version = scanForAPIVersion(address)
 
+	fmt.Printf("endpoint.newEndpoint: trimmedAddress=%s, version=%s\n", trimmedAddress, endpoint.Version)
 	if endpoint.URL, err = url.Parse(trimmedAddress); err != nil {
 		return nil, err
 	}
@@ -162,7 +174,7 @@ func (e *Endpoint) Ping() (RegistryInfo, error) {
 func (e *Endpoint) pingV1() (RegistryInfo, error) {
 	log.Debugf("attempting v1 ping for registry endpoint %s", e)
 
-	if e.String() == IndexServerAddress() {
+	if e.String() == INDEXSERVER {
 		// Skip the check, we know this one is valid
 		// (and we never want to fallback to http in case of error)
 		return RegistryInfo{Standalone: false}, nil

--- a/registry/endpoint_test.go
+++ b/registry/endpoint_test.go
@@ -11,15 +11,17 @@ func TestEndpointParse(t *testing.T) {
 	testData := []struct {
 		str      string
 		expected string
+		secure   bool
 	}{
-		{IndexServerAddress(), IndexServerAddress()},
-		{"http://0.0.0.0:5000/v1/", "http://0.0.0.0:5000/v1/"},
-		{"http://0.0.0.0:5000/v2/", "http://0.0.0.0:5000/v2/"},
-		{"http://0.0.0.0:5000", "http://0.0.0.0:5000/v0/"},
-		{"0.0.0.0:5000", "https://0.0.0.0:5000/v0/"},
+		{IndexServerAddress(""), IndexServerAddress(""), true},
+		{"http://0.0.0.0:5000/v1/", "http://0.0.0.0:5000/v1/", false},
+		{"http://0.0.0.0:5000/v2/", "http://0.0.0.0:5000/v2/", false},
+		{"http://0.0.0.0:5000", "http://0.0.0.0:5000/v0/", false},
+		{"0.0.0.0:5000", "https://0.0.0.0:5000/v0/", true},
+		{"0.0.0.0:5000", "http://0.0.0.0:5000/v0/", false},
 	}
 	for _, td := range testData {
-		e, err := newEndpoint(td.str, false)
+		e, err := newEndpoint(td.str, td.secure)
 		if err != nil {
 			t.Errorf("%q: %s", td.str, err)
 		}

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -164,7 +164,7 @@ func makeHttpsIndex(req string) *IndexInfo {
 
 func makePublicIndex() *IndexInfo {
 	index := &IndexInfo{
-		Name:     IndexServerAddress(),
+		Name:     IndexServerAddress(""),
 		Secure:   true,
 		Official: true,
 	}

--- a/registry/service.go
+++ b/registry/service.go
@@ -1,10 +1,13 @@
 package registry
 
 import (
+	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/engine"
 )
 
+// List of indexes to query.
+// The lower the index, the higher the priority.
 var RegistryList = []string{INDEXNAME}
 
 // Service exposes registry capabilities in the standard Engine
@@ -54,7 +57,7 @@ func (s *Service) Auth(job *engine.Job) engine.Status {
 	addr := authConfig.ServerAddress
 	if addr == "" {
 		// Use the official registry address if not specified.
-		addr = IndexServerAddress()
+		addr = IndexServerAddress("")
 	}
 
 	if index, err = ResolveIndexInfo(job, addr); err != nil {
@@ -107,28 +110,58 @@ func (s *Service) Search(job *engine.Job) engine.Status {
 	job.GetenvJson("authConfig", authConfig)
 	job.GetenvJson("metaHeaders", metaHeaders)
 
-	repoInfo, err := ResolveRepositoryInfo(job, term)
-	if err != nil {
-		return job.Error(err)
-	}
-	// *TODO: Search multiple indexes.
-	endpoint, err := repoInfo.GetEndpoint()
-	if err != nil {
-		return job.Error(err)
-	}
-	r, err := NewSession(authConfig, HTTPRequestFactory(metaHeaders), endpoint, true)
-	if err != nil {
-		return job.Error(err)
-	}
-	results, err := r.SearchRepositories(repoInfo.GetSearchTerm())
-	if err != nil {
-		return job.Error(err)
-	}
 	outs := engine.NewTable("star_count", 0)
-	for _, result := range results.Results {
-		out := &engine.Env{}
-		out.Import(result)
-		outs.Add(out)
+
+	doSearch := func(term string) error {
+		repoInfo, err := ResolveRepositoryInfo(job, term)
+		if err != nil {
+			return err
+		}
+		// *TODO: Search multiple indexes.
+		endpoint, err := repoInfo.GetEndpoint()
+		if err != nil {
+			return err
+		}
+		r, err := NewSession(authConfig, HTTPRequestFactory(metaHeaders), endpoint, true)
+		if err != nil {
+			return err
+		}
+		results, err := r.SearchRepositories(repoInfo.GetSearchTerm())
+		if err != nil {
+			return err
+		}
+		for _, result := range results.Results {
+			out := &engine.Env{}
+			out.Import(result)
+			outs.Add(out)
+		}
+		return nil
+	}
+	if RepositoryNameHasIndex(term) {
+		if err := doSearch(term); err != nil {
+			return job.Error(err)
+		}
+	} else {
+		var (
+			err              error
+			successfulSearch = false
+		)
+		for i, r := range RegistryList {
+			if i > 0 {
+				job.Args[0] = fmt.Sprintf("%s/%s", r, term)
+			} else {
+				job.Args[0] = term
+			}
+			err = doSearch(job.Args[0])
+			if err == nil {
+				successfulSearch = true
+			} else {
+				log.Errorf("%s", err.Error())
+			}
+		}
+		if !successfulSearch {
+			return job.Error(err)
+		}
 	}
 	outs.ReverseSort()
 	if _, err := outs.WriteListTo(job.Stdout); err != nil {

--- a/registry/session.go
+++ b/registry/session.go
@@ -48,13 +48,13 @@ func NewSession(authConfig *AuthConfig, factory *utils.HTTPRequestFactory, endpo
 
 	// If we're working with a standalone private registry over HTTPS, send Basic Auth headers
 	// alongside our requests.
-	if r.indexEndpoint.VersionString(1) != IndexServerAddress() && r.indexEndpoint.URL.Scheme == "https" {
+	if r.indexEndpoint.VersionString(1) != INDEXSERVER && r.indexEndpoint.URL.Scheme == "https" {
 		info, err := r.indexEndpoint.Ping()
 		if err != nil {
 			return nil, err
 		}
 		if info.Standalone {
-			log.Debugf("Endpoint %s is eligible for private registry registry. Enabling decorator.", r.indexEndpoint.String())
+			log.Debugf("Endpoint %s is eligible for private registry. Enabling decorator.", r.indexEndpoint.String())
 			dec := utils.NewHTTPAuthDecorator(authConfig.Username, authConfig.Password)
 			factory.AddDecorator(dec)
 		}

--- a/registry/session_v2.go
+++ b/registry/session_v2.go
@@ -22,7 +22,7 @@ func getV2Builder(e *Endpoint) *v2.URLBuilder {
 func (r *Session) V2RegistryEndpoint(index *IndexInfo) (ep *Endpoint, err error) {
 	// TODO check if should use Mirror
 	if index.Official {
-		ep, err = newEndpoint(REGISTRYSERVER, true)
+		ep, err = newEndpoint(RegistryServerAddress(index.Name), true)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
This PR fixes support for --registry-append and --registry-replace options
for pull command and adds their support for search command.
    
Pull and Search commands iterate over a list of registries given with
options --registry-append or --registry-replace. In case of pull command
the iteration stops when a matching image is found. In case of search
command the iteration never stops - all the results are accumulated.

--registry-append is kind of confusing - it does exact oposite. It
prepends registries separated with commas in reversed order to official
index (docker.io). So the last registry specified is queried as the
first one.

TODO:
  * rename --registry-append to something like --registry-prepend.
  * add a repository origin to the results table for search command if
    multiple registries were queried