### PR TITLE
Polished the addition of --registry(append|replace) flags

### DIFF
--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -63,7 +63,9 @@ complete -c docker -f -n '__fish_docker_no_subcommand' -l ip-masq -d "Enable IP 
 complete -c docker -f -n '__fish_docker_no_subcommand' -l iptables -d "Enable Docker's addition of iptables rules"
 complete -c docker -f -n '__fish_docker_no_subcommand' -l mtu -d 'Set the containers network MTU'
 complete -c docker -f -n '__fish_docker_no_subcommand' -s p -l pidfile -d 'Path to use for daemon PID file'
-complete -c docker -f -n '__fish_docker_no_subcommand' -l registry-mirror -d 'Specify a preferred Docker registry mirror'
+complete -c docker -f -n '__fish_docker_no_subcommand' -l registry-mirror -d "Specify a preferred Docker registry mirror for pulls from official registry"
+complete -c docker -f -n '__fish_docker_no_subcommand' -l registry-replace -d "Registry that shall replace official registry and index. Registry is expected to be insecure."
+complete -c docker -f -n '__fish_docker_no_subcommand' -l registry-prepend -d "Each given registry will be prepended to a list of registries queried during image pulls or searches. The last registry given will be queried first. They will be treated as insecure."
 complete -c docker -f -n '__fish_docker_no_subcommand' -s s -l storage-driver -d 'Force the Docker runtime to use a specific storage driver'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l selinux-enabled -d 'Enable selinux support. SELinux does not presently support the BTRFS storage driver'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l storage-opt -d 'Set storage driver options'

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -33,6 +33,21 @@ func mainDaemon() {
 		flag.Usage()
 		return
 	}
+
+	if *registryCfg.DefaultRegistry != "" {
+		defaultRegistry, err := registry.ValidateIndexName(*registryCfg.DefaultRegistry)
+		if err != nil {
+			log.Fatal("Given invalid default registry \"%s\": %s", *registryCfg.DefaultRegistry, err.Error())
+		}
+		registry.RegistryList[0] = defaultRegistry
+	}
+
+	for _, r := range registryCfg.AdditionalRegistries.GetAll() {
+		if r != "" {
+			registry.RegistryList = append([]string{r}, registry.RegistryList...)
+		}
+	}
+
 	eng := engine.New()
 	signal.Trap(eng.Shutdown)
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/dockerversion"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/reexec"
-	"github.com/docker/docker/registry"
 	"github.com/docker/docker/utils"
 )
 
@@ -36,19 +35,6 @@ func main() {
 	if *flVersion {
 		showVersion()
 		return
-	}
-
-	if *flDefaultRegistry != "" {
-		registry.RegistryList = strings.Split(*flDefaultRegistry, ",")
-	}
-
-	if *flAppendRegistry != "" {
-		regs := strings.Split(*flAppendRegistry, ",")
-		for r := range regs {
-			// TODO: we actually prepend here - reflect this in the option name
-			// (--registry-prepend)
-			registry.RegistryList = append([]string{regs[r]}, registry.RegistryList...)
-		}
 	}
 
 	if *flLogLevel != "" {

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -29,17 +29,15 @@ func getHomeDir() string {
 }
 
 var (
-	flAppendRegistry  = flag.String([]string{"#registry-append", "-registry-append"}, "", "Comma separated list of registries to append to default registry. Registries will be searched in reverse order")
-	flDefaultRegistry = flag.String([]string{"#registry-replace", "-registry-replace"}, "", "Comma separated list of registries to replace the default registry. Registries will be searched in reverse order")
-	flVersion         = flag.Bool([]string{"v", "-version"}, false, "Print version information and quit")
-	flDaemon          = flag.Bool([]string{"d", "-daemon"}, false, "Enable daemon mode")
-	flDebug           = flag.Bool([]string{"D", "-debug"}, false, "Enable debug mode")
-	flSocketGroup     = flag.String([]string{"G", "-group"}, "docker", "Group to assign the unix socket specified by -H when running in daemon mode\nuse '' (the empty string) to disable setting of a group")
-	flLogLevel        = flag.String([]string{"l", "-log-level"}, "info", "Set the logging level (debug, info, warn, error, fatal)")
-	flEnableCors      = flag.Bool([]string{"#api-enable-cors", "-api-enable-cors"}, false, "Enable CORS headers in the remote API")
-	flTls             = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by --tlsverify flag")
-	flHelp            = flag.Bool([]string{"h", "-help"}, false, "Print usage")
-	flTlsVerify       = flag.Bool([]string{"-tlsverify"}, dockerTlsVerify, "Use TLS and verify the remote (daemon: verify client, client: verify daemon)")
+	flVersion     = flag.Bool([]string{"v", "-version"}, false, "Print version information and quit")
+	flDaemon      = flag.Bool([]string{"d", "-daemon"}, false, "Enable daemon mode")
+	flDebug       = flag.Bool([]string{"D", "-debug"}, false, "Enable debug mode")
+	flSocketGroup = flag.String([]string{"G", "-group"}, "docker", "Group to assign the unix socket specified by -H when running in daemon mode\nuse '' (the empty string) to disable setting of a group")
+	flLogLevel    = flag.String([]string{"l", "-log-level"}, "info", "Set the logging level (debug, info, warn, error, fatal)")
+	flEnableCors  = flag.Bool([]string{"#api-enable-cors", "-api-enable-cors"}, false, "Enable CORS headers in the remote API")
+	flTls         = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by --tlsverify flag")
+	flHelp        = flag.Bool([]string{"h", "-help"}, false, "Print usage")
+	flTlsVerify   = flag.Bool([]string{"-tlsverify"}, dockerTlsVerify, "Use TLS and verify the remote (daemon: verify client, client: verify daemon)")
 
 	// these are initialized in init() below since their default values depend on dockerCertPath which isn't fully initialized until init() runs
 	flTrustKey *string

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -89,7 +89,13 @@ unix://[/path/to/socket] to use.
   Path to use for daemon PID file. Default is `/var/run/docker.pid`
 
 **--registry-mirror**=<scheme>://<host>
-  Prepend a registry mirror to be used for image pulls. May be specified multiple times.
+  Prepend a registry mirror to be used for image pulls from public Docker registry. May be specified multiple times.
+
+**--registry-prepend**=[]
+  Each given registry will be prepended to a list of registries queried during image pulls or searches. The last registry given will be queried first. They will be treated as insecure. Registry mirrors won't apply to them.
+
+**--registry-replace**=""
+  Registry that shall replace official Docker registry and index (e.g. 10.172.10.2:5000, private-registry.foo.bar). Additional registries added with --registry-prepend will be queried before this one. Use this option if you do not want to query official registry at all. It will be treated as insecure. Registry mirrors won't apply to given registry.
 
 **-s**=""
   Force the Docker runtime to use a specific storage driver.
@@ -99,12 +105,6 @@ unix://[/path/to/socket] to use.
 
 **-v**=*true*|*false*
   Print version information and quit. Default is false.
-
-**--registry-append**=""
-  Comma separated list of registries to append to default registry. Registries will be searched in reverse order.
-
-**--registry-replace**=""
-Comma separated list of registries to replace the default registry. Registries will be searched in reverse order
 
 **--selinux-enabled**=*true*|*false*
   Enable selinux support. Default is false. SELinux does not presently support the BTRFS storage driver.

--- a/registry/service.go
+++ b/registry/service.go
@@ -6,10 +6,6 @@ import (
 	"github.com/docker/docker/engine"
 )
 
-// List of indexes to query.
-// The lower the index, the higher the priority.
-var RegistryList = []string{INDEXNAME}
-
 // Service exposes registry capabilities in the standard Engine
 // interface. Once installed, it extends the engine with the
 // following calls:
@@ -117,7 +113,6 @@ func (s *Service) Search(job *engine.Job) engine.Status {
 		if err != nil {
 			return err
 		}
-		// *TODO: Search multiple indexes.
 		endpoint, err := repoInfo.GetEndpoint()
 		if err != nil {
 			return err


### PR DESCRIPTION
* --registry-append renamed to --registry-prepend
 * --registry-prepend has the same notation as --registry-mirror
   This option needs to be specified multiple times for each registry
   instead of once with registries given as comma-separated list.
 * --registry-replace now accepts exactly one registry
 * documentation updates

Signed-off-by: Michal Minar <miminar@redhat.com>