### PR TITLE
Add --add-registry and --block-registry options to docker daemon

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -565,6 +565,7 @@ func postImagesCreate(eng *engine.Engine, version version.Version, w http.Respon
 		job.SetenvBool("parallel", version.GreaterThan("1.3"))
 		job.SetenvJson("metaHeaders", metaHeaders)
 		job.SetenvJson("authConfig", authConfig)
+		job.SetenvBool("protectOfficialRegistry", false)
 	} else { //import
 		if tag == "" {
 			repo, tag = parsers.ParseRepositoryTag(repo)

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -439,6 +439,7 @@ func (b *Builder) pullImage(name string) (*imagepkg.Image, error) {
 	job.SetenvBool("json", b.StreamFormatter.Json())
 	job.SetenvBool("parallel", true)
 	job.SetenvJson("authConfig", pullRegistryAuth)
+	job.SetenvBool("protectOfficialRegistry", true)
 	job.Stdout.Add(ioutils.NopWriteCloser(b.OutOld))
 	if err := job.Run(); err != nil {
 		return nil, err

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -932,7 +932,9 @@ _docker() {
 	)
 
 	local main_options_with_args="
+		--add-registry
 		--bip
+		--block-registry
 		--bridge -b
 		--dns
 		--dns-search

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -43,9 +43,11 @@ function __fish_print_docker_repositories --description 'Print a list of docker 
 end
 
 # common options
+complete -c docker -f -n '__fish_docker_no_subcommand' -l add-registry -d 'Query given registry before a public one'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l api-enable-cors -d 'Enable CORS headers in the remote API'
 complete -c docker -f -n '__fish_docker_no_subcommand' -s b -l bridge -d 'Attach containers to a pre-existing network bridge'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l bip -d "Use this CIDR notation address for the network bridge's IP, not compatible with -b"
+complete -c docker -f -n '__fish_docker_no_subcommand' -l block-registry -d "Don't contact given registry"
 complete -c docker -f -n '__fish_docker_no_subcommand' -s D -l debug -d 'Enable debug mode'
 complete -c docker -f -n '__fish_docker_no_subcommand' -s d -l daemon -d 'Enable daemon mode'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l dns -d 'Force Docker to use specific DNS servers'
@@ -68,7 +70,7 @@ complete -c docker -f -n '__fish_docker_no_subcommand' -s l -l log-level -d 'Set
 complete -c docker -f -n '__fish_docker_no_subcommand' -l label -d 'Set key=value labels to the daemon (displayed in `docker info`)'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l mtu -d 'Set the containers network MTU'
 complete -c docker -f -n '__fish_docker_no_subcommand' -s p -l pidfile -d 'Path to use for daemon PID file'
-complete -c docker -f -n '__fish_docker_no_subcommand' -l registry-mirror -d 'Specify a preferred Docker registry mirror'
+complete -c docker -f -n '__fish_docker_no_subcommand' -l registry-mirror -d "Specify a preferred Docker registry mirror for pulls from official registry"
 complete -c docker -f -n '__fish_docker_no_subcommand' -s s -l storage-driver -d 'Force the Docker runtime to use a specific storage driver'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l selinux-enabled -d 'Enable selinux support. SELinux does not presently support the BTRFS storage driver'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l storage-opt -d 'Set storage driver options'

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/ulimit"
+	"github.com/docker/docker/registry"
 )
 
 const (
@@ -46,6 +47,8 @@ type Config struct {
 	TrustKeyPath                string
 	Labels                      []string
 	Ulimits                     map[string]*ulimit.Ulimit
+	BlockedRegistries           opts.ListOpts
+	AdditionalRegistries        opts.ListOpts
 }
 
 // InstallFlags adds command-line options to the top-level flag parser for
@@ -79,6 +82,10 @@ func (config *Config) InstallFlags() {
 	opts.LabelListVar(&config.Labels, []string{"-label"}, "Set key=value labels to the daemon")
 	config.Ulimits = make(map[string]*ulimit.Ulimit)
 	opts.UlimitMapVar(&config.Ulimits, []string{"-default-ulimit"}, "Set default ulimits for containers")
+	config.BlockedRegistries = opts.NewListOpts(registry.ValidateIndexName)
+	flag.Var(&config.BlockedRegistries, []string{"-block-registry"}, "Don't contact given registry")
+	config.AdditionalRegistries = opts.NewListOpts(registry.ValidateIndexName)
+	flag.Var(&config.AdditionalRegistries, []string{"-add-registry"}, "Registry to query before a public one")
 }
 
 func getDefaultNetworkMtu() int {

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -80,6 +80,25 @@ func mainDaemon() {
 		flag.Usage()
 		return
 	}
+
+	for _, r := range daemonCfg.BlockedRegistries.GetAll() {
+		if r == "public" {
+			r = registry.INDEXNAME
+		}
+		registry.BlockedRegistries[r] = struct{}{}
+		if r == registry.INDEXNAME {
+			registry.RegistryList = []string{}
+		}
+	}
+
+	newRegistryList := []string{}
+	for _, r := range daemonCfg.AdditionalRegistries.GetAll() {
+		if _, ok := registry.BlockedRegistries[r]; !ok {
+			newRegistryList = append(newRegistryList, r)
+		}
+	}
+	registry.RegistryList = append(newRegistryList, registry.RegistryList...)
+
 	eng := engine.New()
 	signal.Trap(eng.Shutdown)
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/dockerversion"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/reexec"
-	"github.com/docker/docker/registry"
 	"github.com/docker/docker/utils"
 )
 
@@ -36,19 +35,6 @@ func main() {
 	if *flVersion {
 		showVersion()
 		return
-	}
-
-	if *flDefaultRegistry != "" {
-		registry.RegistryList = strings.Split(*flDefaultRegistry, ",")
-	}
-
-	if *flPrependRegistry != "" {
-		regs := strings.Split(*flPrependRegistry, ",")
-		for r := range regs {
-			// TODO: we actually prepend here - reflect this in the option name
-			// (--registry-prepend)
-			registry.RegistryList = append([]string{regs[r]}, registry.RegistryList...)
-		}
 	}
 
 	if *flLogLevel != "" {
@@ -93,6 +79,11 @@ func main() {
 	}
 	protoAddrParts := strings.SplitN(flHosts[0], "://", 2)
 
+	for _, lopt := range []string{"-add-registry", "-block-registry"} {
+		if flag.IsSet(lopt) {
+			log.Fatalf("The -%s option is recognized only by Docker daemon.", lopt)
+		}
+	}
 	var (
 		cli       *client.DockerCli
 		tlsConfig tls.Config

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -39,9 +39,6 @@ var (
 	flHelp      = flag.Bool([]string{"h", "-help"}, false, "Print usage")
 	flTlsVerify = flag.Bool([]string{"-tlsverify"}, dockerTlsVerify, "Use TLS and verify the remote")
 
-	flPrependRegistry = flag.String([]string{"#registry-prepend", "-registry-prepend"}, "", "Comma separated list of registries to prepend to default registry. Registries will be searched in reverse order")
-	flDefaultRegistry = flag.String([]string{"#registry-replace", "-registry-replace"}, "", "Comma separated list of registries to replace the default registry. Registries will be searched in reverse order")
-
 	// these are initialized in init() below since their default values depend on dockerCertPath which isn't fully initialized until init() runs
 	flTrustKey *string
 	flCa       *string

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -34,6 +34,9 @@ unix://[/path/to/socket] to use.
    The socket(s) to bind to in daemon mode specified using one or more
    tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.
 
+**--add-registry**=[]
+  **EXPERIMENTAL** Each given registry will be queried before a public Docker registry during image pulls or searches. They will be searched in the order given. Registry mirrors won't apply to them.
+
 **--api-enable-cors**=*true*|*false*
   Enable CORS headers in the remote API. Default is false.
 
@@ -42,6 +45,9 @@ unix://[/path/to/socket] to use.
 
 **--bip**=""
   Use the provided CIDR notation address for the dynamically created bridge (docker0); Mutually exclusive of \-b
+
+**--block-registry**=[]
+  **EXPERIMENTAL** Prevent Docker daemon from contacting specified registries. Special keyword "public" represents public Docker registry.
 
 **-d**=*true*|*false*
   Enable daemon mode. Default is false.
@@ -89,7 +95,7 @@ unix://[/path/to/socket] to use.
   Path to use for daemon PID file. Default is `/var/run/docker.pid`
 
 **--registry-mirror**=<scheme>://<host>
-  Prepend a registry mirror to be used for image pulls. May be specified multiple times.
+  Prepend a registry mirror to be used for image pulls from public Docker registry. May be specified multiple times.
 
 **-s**=""
   Force the Docker runtime to use a specific storage driver.
@@ -99,12 +105,6 @@ unix://[/path/to/socket] to use.
 
 **-v**=*true*|*false*
   Print version information and quit. Default is false.
-
-**--registry-prepend**=""
-  Comma separated list of registries to prepend to default registry. Registries will be searched in reverse order.
-
-**--registry-replace**=""
-Comma separated list of registries to replace the default registry. Registries will be searched in reverse order
 
 **--selinux-enabled**=*true*|*false*
   Enable selinux support. Default is false. SELinux does not presently support the BTRFS storage driver.

--- a/graph/export.go
+++ b/graph/export.go
@@ -40,7 +40,9 @@ func (s *TagStore) CmdImageExport(job *engine.Job) engine.Status {
 		}
 	}
 	for _, name := range job.Args {
-		name = registry.NormalizeLocalName(name)
+		if _, exists := s.Repositories[name]; !exists {
+			name = registry.NormalizeLocalName(name)
+		}
 		log.Debugf("Serializing %s", name)
 		rootRepo := s.Repositories[name]
 		if rootRepo != nil {

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -28,6 +28,13 @@ func (s *TagStore) CmdRegistryPull(job *engine.Job) engine.Status {
 	// the matching image is found.
 	if registry.RepositoryNameHasIndex(tmp) {
 		registries = []string{""}
+	} else if len(registries) == 0 {
+		return job.Errorf("No configured registry to pull from.")
+	} else if job.GetenvBool("protectOfficialRegistry") && registries[0] != registry.INDEXNAME {
+		// We must ensure that registry missing hostname will be pulled from
+		// official one, if the `protectOfficialRegistry` tells us so.
+		registries = []string{""}
+		tmp = fmt.Sprintf("%s/%s", registry.INDEXNAME, tmp)
 	}
 	for i, r := range registries {
 		if i > 0 {

--- a/registry/service.go
+++ b/registry/service.go
@@ -6,10 +6,6 @@ import (
 	"github.com/docker/docker/engine"
 )
 
-// List of indexes to query.
-// The lower the index, the higher the priority.
-var RegistryList = []string{INDEXNAME}
-
 // Service exposes registry capabilities in the standard Engine
 // interface. Once installed, it extends the engine with the
 // following calls:
@@ -58,6 +54,9 @@ func (s *Service) Auth(job *engine.Job) engine.Status {
 	if addr == "" {
 		// Use the official registry address if not specified.
 		addr = IndexServerAddress("")
+	}
+	if addr == "" {
+		return job.Errorf("No configured registry to authenticate to.")
 	}
 
 	if index, err = ResolveIndexInfo(job, addr); err != nil {
@@ -117,7 +116,6 @@ func (s *Service) Search(job *engine.Job) engine.Status {
 		if err != nil {
 			return err
 		}
-		// *TODO: Search multiple indexes.
 		endpoint, err := repoInfo.GetEndpoint()
 		if err != nil {
 			return err
@@ -141,6 +139,8 @@ func (s *Service) Search(job *engine.Job) engine.Status {
 		if err := doSearch(term); err != nil {
 			return job.Error(err)
 		}
+	} else if len(RegistryList) < 1 {
+		return job.Errorf("No configured repository to search.")
 	} else {
 		var (
 			err              error


### PR DESCRIPTION
The first option allows to prepend additional registries to a public
    one. These will be queried one after another - in the same order
    they were given - when pulling images.

    For example:

        --add-registry=foo.com
        --add-registry=bar.com

    Would cause a

        docker pull myapp

    to search

        foo.com/myapp
        bar.com/myapp
        docker.io/myapp

    The second option builds a list of banned registries. Docker daemon
    will prevent user from any communication with such registries. This
    option recognizes a special keyword "public" denoting public Docker
    registry.

    So for example adding

        --block-registry=public

    to flags of previous example would result in searching the same
    registries except for `docker.io/myapp`

    Both flags are marked as experimental in man pages.

    This would allow companies and vendors to specify registries which
    contain content that the companies will not allowed to be stored at
    docker.io.

    The FROM statement in Dockerfile keeps its old behaviour. If the
    repository is missing registry, it will be pulled from the official
    one.

Docker-DCO-1.1-Signed-off-by: Dan Walsh <dwalsh@redhat.com> (github: rhatdan)

Signed-off-by: Michal Minar <miminar@redhat.com>

Conflicts:
	graph/pull.go
	registry/config.go
	registry/service.go

Conflicts:
	daemon/config.go