### PR TITLE
Add --add-registry and --block-registry options to docker daemon

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -45,9 +45,6 @@ func (s *TagStore) CmdRegistryPull(job *engine.Job) engine.Status {
 		}
 		status := s.CmdPull(job)
 		if status == engine.StatusOK {
-			tagjob := job
-			tagjob.Args = append(tagjob.Args, tmp)
-			s.CmdTag(tagjob)
 			return status
 		}
 	}

--- a/registry/endpoint.go
+++ b/registry/endpoint.go
@@ -22,9 +22,6 @@ func scanForAPIVersion(address string) (string, APIVersion) {
 		chunks        []string
 		apiVersionStr string
 	)
-	log.Debugf("endpoint.scanForAPIVersion: starting with address=%s", address)
-	defer log.Debugf("endpoint.scanForAPIVersion: terminating")
-
 	if strings.HasSuffix(address, "/") {
 		address = address[:len(address)-1]
 	}
@@ -45,8 +42,6 @@ func scanForAPIVersion(address string) (string, APIVersion) {
 // NewEndpoint parses the given address to return a registry endpoint.
 func NewEndpoint(index *IndexInfo) (*Endpoint, error) {
 	// *TODO: Allow per-registry configuration of endpoints.
-	log.Debugf("endpoint.NewEndpoint: starting with index=%v", index)
-	defer log.Debugf("endpoint.NewEndpoint: terminating")
 	endpoint, err := newEndpoint(index.GetAuthConfigKey(), index.Secure)
 	if err != nil {
 		return nil, err
@@ -91,9 +86,6 @@ func newEndpoint(address string, secure bool) (*Endpoint, error) {
 		trimmedAddress string
 		err            error
 	)
-	fmt.Printf("endpoint.newEndpoint: starting with address=%s, secure=%t\n", address, secure)
-	defer fmt.Printf("endpoint.newEndpoint: terminating\n")
-
 	if !strings.HasPrefix(address, "http") {
 		if secure {
 			address = "https://" + address
@@ -102,10 +94,8 @@ func newEndpoint(address string, secure bool) (*Endpoint, error) {
 		}
 	}
 
-	fmt.Printf("endpoint.newEndpoint: address after prefixing: %s\n", address)
 	trimmedAddress, endpoint.Version = scanForAPIVersion(address)
 
-	fmt.Printf("endpoint.newEndpoint: trimmedAddress=%s, version=%s\n", trimmedAddress, endpoint.Version)
 	if endpoint.URL, err = url.Parse(trimmedAddress); err != nil {
 		return nil, err
 	}

--- a/registry/session.go
+++ b/registry/session.go
@@ -32,6 +32,13 @@ type Session struct {
 }
 
 func NewSession(authConfig *AuthConfig, factory *utils.HTTPRequestFactory, endpoint *Endpoint, timeout bool) (r *Session, err error) {
+	if authConfig.ServerAddress != "" {
+		parsed, err := url.Parse(authConfig.ServerAddress)
+		if err == nil && parsed.Host != endpoint.URL.Host {
+			log.Infof("authConfig does not conform to given endpoint (%s != %s)", parsed.Host, endpoint.URL.Host)
+			*authConfig = AuthConfig{}
+		}
+	}
 	r = &Session{
 		authConfig:    authConfig,
 		indexEndpoint: endpoint,


### PR DESCRIPTION
The first option allows to prepend additional registries to a public
one. These will be queried one after another - in the same order
they were given - when pulling images.

For example:

    --add-registry=foo.com
    --add-registry=bar.com

Would cause a

    docker pull myapp

to search

    foo.com/myapp
    bar.com/myapp
    docker.io/myapp

The second option builds a list of banned registries. Docker daemon
will prevent user from any communication with such registries. This
option recognizes a special keyword "public" denoting public Docker
registry.

So for example adding

    --block-registry=public

to flags of previous example would result in searching the same
registries except for `docker.io/myapp`

Both flags are marked as experimental in man pages.

This would allow companies and vendors to specify registries which
contain content that the companies will not allowed to be stored at
docker.io.

The FROM statement in Dockerfile keeps its old behaviour. If the
repository is missing registry, it will be pulled from the official
one.

Docker-DCO-1.1-Signed-off-by: Dan Walsh <dwalsh@redhat.com> (github: rhatdan)

Signed-off-by: Michal Minar <miminar@redhat.com>