### PR TITLE
Support "all" keyword with --block-registry flag

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -82,11 +82,13 @@ func mainDaemon() {
 	}
 
 	for _, r := range daemonCfg.BlockedRegistries.GetAll() {
-		if r == "public" {
+		if r == "all" {
+			r = "*"
+		} else if r == "public" {
 			r = registry.INDEXNAME
 		}
 		registry.BlockedRegistries[r] = struct{}{}
-		if r == registry.INDEXNAME {
+		if r == registry.INDEXNAME || r == "*" {
 			registry.RegistryList = []string{}
 		}
 	}

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -47,7 +47,7 @@ unix://[/path/to/socket] to use.
   Use the provided CIDR notation address for the dynamically created bridge (docker0); Mutually exclusive of \-b
 
 **--block-registry**=[]
-  **EXPERIMENTAL** Prevent Docker daemon from contacting specified registries. Special keyword "public" represents public Docker registry.
+  **EXPERIMENTAL** Prevent Docker daemon from contacting specified registries. There are two special keywords recognized. The first is "public" and represents public Docker registry. The second is "all" which causes all registries but those added with **--add-registry** flag to be blocked.
 
 **-d**=*true*|*false*
   Enable daemon mode. Default is false.

--- a/registry/session.go
+++ b/registry/session.go
@@ -209,7 +209,7 @@ func (r *Session) GetRemoteImageLayer(imgID, registry string, token []string, im
 
 func isEndpointBlocked(endpoint string) bool {
 	if parsedURL, err := url.Parse(endpoint); err == nil {
-		if _, ok := BlockedRegistries[parsedURL.Host]; !ok {
+		if !IsIndexBlocked(parsedURL.Host) {
 			return false
 		}
 	}


### PR DESCRIPTION
Supplying `--block-registry=all` to docker daemon will prevent docker
from contacting any registry except for those added with
`--add-registry` flag.

Signed-off-by: Michal Minar <miminar@redhat.com>