### PR TITLE
Adding tests for additional registries and a fix for naming issue

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4901,3 +4901,193 @@ func TestBuildEmptyScratch(t *testing.T) {
 	}
 	logDone("build - empty scratch Dockerfile")
 }
+
+func TestBuildWithAdditionalRegistry(t *testing.T) {
+	name := "testbuildwithadditionalregistry"
+	reg := setupAndGetRegistryAt(t, privateRegistryURLs[0])
+	defer reg.Close()
+	d := NewDaemon(t)
+	if err := d.StartWithBusybox("--add-registry=" + reg.url); err != nil {
+		t.Fatalf("we should have been able to start the daemon with passing add-registry=%s: %v", reg.url, err)
+	}
+	defer d.Stop()
+	busyboxId := d.getAndTestImageEntry(t, 1, reg.url+"/busybox", "").id
+
+	// build image based on hello-world from docker.io
+	_, _, err := d.buildImageWithOut(name, fmt.Sprintf(`
+  FROM library/hello-world
+  ENV test %s
+  `, name), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helloWorldId := d.getAndTestImageEntry(t, 3, "docker.io/hello-world", "").id
+	if helloWorldId == busyboxId {
+		t.Fatalf("docker.io/hello-world must have different ID than busybox image")
+	}
+	buildId := d.getAndTestImageEntry(t, 3, reg.url+"/"+name, "").id
+	if buildId == helloWorldId || buildId == busyboxId {
+		t.Fatalf("built image %s must have different ID than other images", reg.url+"/"+name)
+	}
+	res, err := d.inspectField(name, "Parent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(res, helloWorldId) {
+		t.Fatal("built image %s should have docker.io/hello-world(id=%s) as a parent, not %s", name, helloWorldId, res)
+	}
+
+	// push busybox to additional registry as "library/hello-world" and remove all local images
+	if out, err := d.Cmd("tag", reg.url+"/busybox", reg.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to tag image %s: error %v, output %q", reg.url+"/busybox", err, out)
+	}
+	if out, err := d.Cmd("push", reg.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to push image %s: error %v, output %q", reg.url+"/library/hello-world", err, out)
+	}
+	toRemove := []string{reg.url + "/library/hello-world", reg.url + "/busybox", "docker.io/hello-world", reg.url + "/" + name}
+	if out, err := d.Cmd("rmi", toRemove...); err != nil {
+		t.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
+	}
+	d.getAndTestImageEntry(t, 0, "", "")
+
+	// Build again. It should result in exatly same image as before even though
+	// additional registry now has "library/hello-world". That's because FROM
+	// treats library/hello-world as `docker.io` repository.
+	_, _, err = d.buildImageWithOut(name, fmt.Sprintf(`
+  FROM library/hello-world
+  ENV test %s
+  `, name), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.getAndTestImageEntry(t, 2, reg.url+"/"+name, "")
+	res, err = d.inspectField(name, "Parent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(res, helloWorldId) {
+		t.Fatal("built image %s should have docker.io/hello-world(id=%s) as a parent, not %s", name, helloWorldId, res)
+	}
+
+	// build again with docker.io explicitly specified
+	_, _, err = d.buildImageWithOut(name, fmt.Sprintf(`
+  FROM docker.io/library/hello-world
+  ENV test %s
+  `, name), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.getAndTestImageEntry(t, 2, reg.url+"/"+name, "")
+	res, err = d.inspectField(name, "Parent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(res, helloWorldId) {
+		t.Fatal("built image %s should have docker.io/hello-world(id=%s) as a parent, not %s", name, helloWorldId, res)
+	}
+
+	// build again from additional registry which needs to be specified explicitly - unlike with pull
+	_, _, err = d.buildImageWithOut(name, fmt.Sprintf(`
+  FROM %s/library/hello-world
+  ENV test %s
+  `, reg.url, name), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.getAndTestImageEntry(t, 3, reg.url+"/library/hello-world", busyboxId)
+	tmpId := d.getAndTestImageEntry(t, 3, reg.url+"/"+name, "").id
+	if tmpId == buildId || tmpId == busyboxId || tmpId == helloWorldId {
+		t.Fatalf("built image must have unique ID")
+	}
+	res, err = d.inspectField(name, "Parent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(res, busyboxId) {
+		t.Fatal("built image %s should have busybox(id=%s) as a parent, not %s", name, busyboxId, res)
+	}
+
+	logDone("build - with additional registry")
+}
+
+// Test building of image based on busybox with public registry blocked. Name
+// of image that shall be built is specified by `name`. Parameter `daemonArgs`
+// shall contain at least one `--block-registry` flag.
+func doTestBuildWithPublicRegistryBlocked(t *testing.T, name string, daemonArgs []string) {
+	allBlocked := false
+	for _, arg := range daemonArgs {
+		if arg == "--block-registry=all" {
+			allBlocked = true
+		}
+	}
+	reg := setupAndGetRegistryAt(t, privateRegistryURLs[0])
+	defer reg.Close()
+	d := NewDaemon(t)
+	if err := d.StartWithBusybox(daemonArgs...); err != nil {
+		t.Fatalf("we should have been able to start the daemon with passing { %s }: %v", strings.Join(daemonArgs, ", "), err)
+	}
+	defer d.Stop()
+	busyboxId := d.getAndTestImageEntry(t, 1, "busybox", "").id
+
+	// try to build image based on hello-world from docker.io
+	_, _, err := d.buildImageWithOut(name, fmt.Sprintf(`
+  FROM library/hello-world
+  ENV test %s
+  `, name), true)
+	if err == nil {
+		t.Fatal("build should have failed because of public registry being blocked")
+	}
+
+	// now base the image on local busybox image
+	_, _, err = d.buildImageWithOut(name, fmt.Sprintf(`
+  FROM busybox
+  ENV test %s
+  `, name), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.getAndTestImageEntry(t, 2, name, "")
+	if res, err := d.inspectField(name, "Parent"); err != nil {
+		t.Fatal(err)
+	} else if !strings.HasPrefix(res, busyboxId) {
+		t.Fatal("built image %s should have busybox(id=%s) as a parent, not %s", name, busyboxId, res)
+	}
+
+	if out, err := d.Cmd("tag", "busybox", reg.url+"/library/busybox"); err != nil {
+		t.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
+	}
+	if out, err := d.Cmd("push", reg.url+"/library/busybox"); !allBlocked && err != nil {
+		t.Fatalf("failed to push image %s: error %v, output %q", reg.url+"/library/busybox", err, out)
+	} else if allBlocked && err == nil {
+		t.Fatalf("push to private registry should have failed, output: %q", out)
+	}
+
+	toRemove := []string{"busybox", reg.url + "/library/busybox"}
+	if out, err := d.Cmd("rmi", toRemove...); err != nil {
+		t.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
+	}
+	d.getAndTestImageEntry(t, 1, name, "")
+
+	// now base the image on busybox from private registry
+	_, _, err = d.buildImageWithOut(name, fmt.Sprintf(`
+  FROM %s/library/busybox
+  ENV test %s
+  `, reg.url, name), true)
+	if !allBlocked && err != nil {
+		t.Fatal(err)
+	} else if allBlocked && err == nil {
+		t.Fatalf("the build should have failed due to all registries being blocked")
+	}
+}
+
+func TestBuildWithPublicRegistryBlocked(t *testing.T) {
+	for _, blockedRegistry := range []string{"public", "docker.io"} {
+		doTestBuildWithPublicRegistryBlocked(t, "testbuildpublicregistryblocked", []string{"--block-registry=" + blockedRegistry})
+	}
+	logDone("build - with public registry blocked")
+}
+
+func TestBuildWithAllRegistriesBlocked(t *testing.T) {
+	doTestBuildWithPublicRegistryBlocked(t, "testbuildwithallregistriesblocked", []string{"--block-registry=all"})
+	logDone("pull - build with all registries blocked")
+}

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -11,7 +11,7 @@ import (
 func TestPullImageWithAliases(t *testing.T) {
 	defer setupRegistry(t)()
 
-	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
+	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURLs[0])
 	defer deleteImages(repoName)
 
 	repos := []string{}
@@ -133,4 +133,354 @@ func TestPullImageOfficialNames(t *testing.T) {
 		}
 	}
 	logDone("pull - pull official names")
+}
+
+func TestPullFromAdditionalRegistry(t *testing.T) {
+	reg := setupAndGetRegistryAt(t, privateRegistryURLs[0])
+	defer reg.Close()
+	d := NewDaemon(t)
+	if err := d.StartWithBusybox("--add-registry=" + reg.url); err != nil {
+		t.Fatalf("we should have been able to start the daemon with passing add-registry=%s: %v", reg.url, err)
+	}
+	defer d.Stop()
+
+	busyboxId := d.getAndTestImageEntry(t, 1, reg.url+"/busybox", "").id
+
+	// this will pull from docker.io
+	if _, err := d.Cmd("pull", "library/hello-world"); err != nil {
+		t.Fatalf("we should have been able to pull library/hello-world from \"%s\": %v", reg.url, err)
+	}
+
+	helloWorldId := d.getAndTestImageEntry(t, 2, "docker.io/hello-world", "").id
+	if helloWorldId == busyboxId {
+		t.Fatalf("docker.io/hello-world must have different ID than busybox image")
+	}
+
+	// push busybox to additional registry as "library/hello-world" and remove all local images
+	if out, err := d.Cmd("tag", reg.url+"/busybox", reg.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to tag image %s: error %v, output %q", reg.url+"/busybox", err, out)
+	}
+	if out, err := d.Cmd("push", reg.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to push image %s: error %v, output %q", reg.url+"/library/hello-world", err, out)
+	}
+	toRemove := []string{reg.url + "/library/hello-world", reg.url + "/busybox", "docker.io/hello-world"}
+	if out, err := d.Cmd("rmi", toRemove...); err != nil {
+		t.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
+	}
+	d.getAndTestImageEntry(t, 0, "", "")
+
+	// pull the same name again - now the image should be pulled from additional registry
+	if _, err := d.Cmd("pull", "library/hello-world"); err != nil {
+		t.Fatalf("we should have been able to pull library/hello-world from \"%s\": %v", reg.url, err)
+	}
+	d.getAndTestImageEntry(t, 1, reg.url+"/library/hello-world", busyboxId)
+
+	// empty images once more
+	if out, err := d.Cmd("rmi", reg.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to remove image %s: %v, output: %s", reg.url+"library/hello-world", err, out)
+	}
+	d.getAndTestImageEntry(t, 0, "", "")
+
+	// now pull with fully qualified name
+	if _, err := d.Cmd("pull", "docker.io/library/hello-world"); err != nil {
+		t.Fatalf("we should have been able to pull docker.io/library/hello-world from \"%s\": %v", reg.url, err)
+	}
+	d.getAndTestImageEntry(t, 1, "docker.io/hello-world", helloWorldId)
+
+	logDone("pull - image from additional registry")
+}
+
+func TestPullFromAdditionalRegistries(t *testing.T) {
+	reg1 := setupAndGetRegistryAt(t, privateRegistryURLs[0])
+	defer reg1.Close()
+	reg2 := setupAndGetRegistryAt(t, privateRegistryURLs[1])
+	defer reg2.Close()
+	d := NewDaemon(t)
+	daemonArgs := []string{"--add-registry=" + reg1.url, "--add-registry=" + reg2.url}
+	if err := d.StartWithBusybox(daemonArgs...); err != nil {
+		t.Fatalf("we should have been able to start the daemon with passing { %s } flags: %v", strings.Join(daemonArgs, ", "), err)
+	}
+	defer d.Stop()
+
+	busyboxId := d.getAndTestImageEntry(t, 1, reg1.url+"/busybox", "").id
+
+	// this will pull from docker.io
+	if _, err := d.Cmd("pull", "library/hello-world"); err != nil {
+		t.Fatalf("we should have been able to pull library/hello-world from \"docker.io\": %v", err)
+	}
+	helloWorldId := d.getAndTestImageEntry(t, 2, "docker.io/hello-world", "").id
+	if helloWorldId == busyboxId {
+		t.Fatalf("docker.io/hello-world must have different ID than busybox image")
+	}
+
+	// push:
+	//  hello-world to 1st additional registry as "misc/hello-world"
+	//  busybox to 2nd additional registry as "library/hello-world"
+	if out, err := d.Cmd("tag", "docker.io/hello-world", reg1.url+"/misc/hello-world"); err != nil {
+		t.Fatalf("failed to tag image %s: error %v, output %q", "docker.io/hello-world", err, out)
+	}
+	if out, err := d.Cmd("tag", reg1.url+"/busybox", reg2.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to tag image %s: error %v, output %q", reg1.url+"/busybox", err, out)
+	}
+	if out, err := d.Cmd("push", reg1.url+"/misc/hello-world"); err != nil {
+		t.Fatalf("failed to push image %s: error %v, output %q", reg1.url+"/misc/hello-world", err, out)
+	}
+	if out, err := d.Cmd("push", reg2.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to push image %s: error %v, output %q", reg2.url+"/library/busybox", err, out)
+	}
+	// and remove all local images
+	toRemove := []string{reg1.url + "/misc/hello-world", reg2.url + "/library/hello-world", reg1.url + "/busybox", "docker.io/hello-world"}
+	if out, err := d.Cmd("rmi", toRemove...); err != nil {
+		t.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
+	}
+	d.getAndTestImageEntry(t, 0, "", "")
+
+	// now pull the "library/hello-world" from 2nd additional registry
+	if _, err := d.Cmd("pull", "library/hello-world"); err != nil {
+		t.Fatalf("we should have been able to pull library/hello-world from \"%s\": %v", reg2.url, err)
+	}
+	d.getAndTestImageEntry(t, 1, reg2.url+"/library/hello-world", busyboxId)
+
+	// now pull the "misc/hello-world" from 1st additional registry
+	if _, err := d.Cmd("pull", "misc/hello-world"); err != nil {
+		t.Fatalf("we should have been able to pull misc/hello-world from \"%s\": %v", reg2.url, err)
+	}
+	d.getAndTestImageEntry(t, 2, reg1.url+"/misc/hello-world", helloWorldId)
+
+	// tag it as library/hello-world and push it to 1st registry
+	if out, err := d.Cmd("tag", reg1.url+"/misc/hello-world", reg1.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to tag image %s: error %v, output %q", reg1.url+"/misc/hello-world", err, out)
+	}
+	if out, err := d.Cmd("push", reg1.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to push image %s: error %v, output %q", reg1.url+"/library/hello-world", err, out)
+	}
+
+	// remove all images
+	toRemove = []string{reg1.url + "/misc/hello-world", reg1.url + "/library/hello-world", reg2.url + "/library/hello-world"}
+	if out, err := d.Cmd("rmi", toRemove...); err != nil {
+		t.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
+	}
+	d.getAndTestImageEntry(t, 0, "", "")
+
+	// now pull "library/hello-world" from 1st additional registry
+	if _, err := d.Cmd("pull", "library/hello-world"); err != nil {
+		t.Fatalf("we should have been able to pull library/hello-world from \"%s\": %v", reg1.url, err)
+	}
+	d.getAndTestImageEntry(t, 1, reg1.url+"/library/hello-world", helloWorldId)
+
+	// now pull fully qualified image from 2nd registry
+	if _, err := d.Cmd("pull", reg2.url+"/library/hello-world"); err != nil {
+		t.Fatalf("we should have been able to pull %s/library/hello-world: %v", reg2.url, err)
+	}
+	d.getAndTestImageEntry(t, 2, reg2.url+"/library/hello-world", busyboxId)
+
+	logDone("pull - image from additional registries")
+}
+
+// Test pulls from blocked public registry and from private registry. This
+// shall be called with various daemonArgs containing at least one
+// `--block-registry` flag.
+func doTestPullFromBlockedPublicRegistry(t *testing.T, daemonArgs []string) {
+	allBlocked := false
+	for _, arg := range daemonArgs {
+		if arg == "--block-registry=all" {
+			allBlocked = true
+		}
+	}
+	reg := setupAndGetRegistryAt(t, privateRegistryURLs[0])
+	defer reg.Close()
+	d := NewDaemon(t)
+	if err := d.StartWithBusybox(daemonArgs...); err != nil {
+		t.Fatalf("we should have been able to start the daemon with passing { %s } flags: %v", strings.Join(daemonArgs, ", "), err)
+	}
+	defer d.Stop()
+
+	busyboxId := d.getAndTestImageEntry(t, 1, "busybox", "").id
+
+	// try to pull from docker.io
+	if out, err := d.Cmd("pull", "library/hello-world"); err == nil {
+		t.Fatalf("pull from blocked public registry should have failed, output: %s", out)
+	}
+
+	// tag busybox as library/hello-world and push it to some private registry
+	if out, err := d.Cmd("tag", "busybox", reg.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
+	}
+	if out, err := d.Cmd("push", reg.url+"/library/hello-world"); !allBlocked && err != nil {
+		t.Fatalf("failed to push image %s: error %v, output %q", reg.url+"/library/hello-world", err, out)
+	} else if allBlocked && err == nil {
+		t.Fatalf("push to private registry should have failed, output: %q", out)
+	}
+
+	// remove library/hello-world image
+	if out, err := d.Cmd("rmi", reg.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to remove images %v: %v, output: %s", reg.url+"/library/hello-world", err, out)
+	}
+	d.getAndTestImageEntry(t, 1, "busybox", busyboxId)
+
+	// try to pull from private registry
+	if out, err := d.Cmd("pull", reg.url+"/library/hello-world"); !allBlocked && err != nil {
+		t.Fatalf("we should have been able to pull %s/library/hello-world: %v", reg.url, err)
+	} else if allBlocked && err == nil {
+		t.Fatalf("pull from private registry should have failed, output: %q", out)
+	} else if !allBlocked {
+		d.getAndTestImageEntry(t, 2, reg.url+"/library/hello-world", busyboxId)
+	}
+}
+
+func TestPullFromBlockedPublicRegistry(t *testing.T) {
+	for _, blockedRegistry := range []string{"public", "docker.io"} {
+		doTestPullFromBlockedPublicRegistry(t, []string{"--block-registry=" + blockedRegistry})
+	}
+	logDone("pull - image from blocked public registry")
+}
+
+func TestPullWithAllRegistriesBlocked(t *testing.T) {
+	doTestPullFromBlockedPublicRegistry(t, []string{"--block-registry=all"})
+	logDone("pull - image with all registries blocked")
+}
+
+// Test pulls from additional registry with public registry blocked. This
+// shall be called with various daemonArgs containing at least one
+// `--block-registry` flag.
+func doTestPullFromPrivateRegistriesWithPublicBlocked(t *testing.T, daemonArgs []string) {
+	allBlocked := false
+	for _, arg := range daemonArgs {
+		if arg == "--block-registry=all" {
+			allBlocked = true
+		}
+	}
+	// additional registry
+	reg1 := setupAndGetRegistryAt(t, privateRegistryURLs[0])
+	defer reg1.Close()
+	// private registry
+	reg2 := setupAndGetRegistryAt(t, privateRegistryURLs[1])
+	defer reg2.Close()
+	d := NewDaemon(t)
+	daemonArgs = append(daemonArgs, "--add-registry="+reg1.url)
+	if err := d.StartWithBusybox(daemonArgs...); err != nil {
+		t.Fatalf("we should have been able to start the daemon with passing { %s } flags: %v", strings.Join(daemonArgs, ", "), err)
+	}
+	defer d.Stop()
+
+	busyboxId := d.getAndTestImageEntry(t, 1, reg1.url+"/busybox", "").id
+
+	// try to pull from blocked public registry
+	if out, err := d.Cmd("pull", "library/hello-world"); err == nil {
+		t.Fatalf("pulling from blocked public registry should have failed, output: %s", out)
+	}
+
+	// push busybox to
+	//  additional registry as "misc/busybox"
+	//  private registry as "library/busybox"
+	// and remove all local images
+	if out, err := d.Cmd("tag", reg1.url+"/busybox", reg1.url+"/misc/busybox"); err != nil {
+		t.Fatalf("failed to tag image %s: error %v, output %q", reg1.url+"/busybox", err, out)
+	}
+	if out, err := d.Cmd("tag", reg1.url+"/busybox", reg2.url+"/library/busybox"); err != nil {
+		t.Fatalf("failed to tag image %s: error %v, output %q", reg1.url+"/busybox", err, out)
+	}
+	if out, err := d.Cmd("push", reg1.url+"/misc/busybox"); err != nil {
+		t.Fatalf("failed to push image %s: error %v, output %q", reg1.url+"/misc/busybox", err, out)
+	}
+	if out, err := d.Cmd("push", reg2.url+"/library/busybox"); !allBlocked && err != nil {
+		t.Fatalf("failed to push image %s: error %v, output %q", reg2.url+"/library/busybox", err, out)
+	} else if allBlocked && err == nil {
+		t.Fatalf("push to private registry should have failed, output: %q", out)
+	}
+	toRemove := []string{reg1.url + "/busybox", reg1.url + "/misc/busybox", reg2.url + "/library/busybox"}
+	if out, err := d.Cmd("rmi", toRemove...); err != nil {
+		t.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
+	}
+	d.getAndTestImageEntry(t, 0, "", "")
+
+	// try to pull "library/busybox" from additional registry
+	if out, err := d.Cmd("pull", "library/busybox"); err == nil {
+		t.Fatalf("pull of library/busybox from additional registry should have failed, output: %q", out)
+	}
+
+	// now pull the "misc/busybox" from additional registry
+	if _, err := d.Cmd("pull", "misc/busybox"); err != nil {
+		t.Fatalf("we should have been able to pull misc/hello-world from \"%s\": %v", reg1.url, err)
+	}
+	d.getAndTestImageEntry(t, 1, reg1.url+"/misc/busybox", busyboxId)
+
+	// try to pull "library/busybox" from private registry
+	if out, err := d.Cmd("pull", reg2.url+"/library/busybox"); !allBlocked && err != nil {
+		t.Fatalf("we should have been able to pull %s/library/busybox: %v", reg2.url, err)
+	} else if allBlocked && err == nil {
+		t.Fatalf("pull from private registry should have failed, output: %q", out)
+	} else if !allBlocked {
+		d.getAndTestImageEntry(t, 2, reg2.url+"/library/busybox", busyboxId)
+	}
+}
+
+func TestPullFromPrivateRegistriesWithPublicBlocked(t *testing.T) {
+	for _, blockedRegistry := range []string{"public", "docker.io"} {
+		doTestPullFromPrivateRegistriesWithPublicBlocked(t, []string{"--block-registry=" + blockedRegistry})
+	}
+	logDone("pull - image from private registries with public registry blocked")
+}
+
+func TestPullFromAdditionalRegistryWithAllBlocked(t *testing.T) {
+	doTestPullFromPrivateRegistriesWithPublicBlocked(t, []string{"--block-registry=all"})
+	logDone("pull - image from additional registry with all the others blocked")
+}
+
+func TestPullFromBlockedRegistry(t *testing.T) {
+	// blocked registry
+	reg1 := setupAndGetRegistryAt(t, privateRegistryURLs[0])
+	defer reg1.Close()
+	// additional registry
+	reg2 := setupAndGetRegistryAt(t, privateRegistryURLs[1])
+	defer reg2.Close()
+	d := NewDaemon(t)
+	daemonArgs := []string{"--block-registry=" + reg1.url, "--add-registry=" + reg2.url}
+	if err := d.StartWithBusybox(daemonArgs...); err != nil {
+		t.Fatalf("we should have been able to start the daemon with passing { %s } flags: %v", strings.Join(daemonArgs, ", "), err)
+	}
+	defer d.Stop()
+
+	busyboxId := d.getAndTestImageEntry(t, 1, reg2.url+"/busybox", "").id
+
+	// pull image from docker.io
+	if _, err := d.Cmd("pull", "library/hello-world"); err != nil {
+		t.Fatalf("we should have been able to pull library/hello-world from \"docker.io\": %v", err)
+	}
+	helloWorldId := d.getAndTestImageEntry(t, 2, "docker.io/hello-world", "").id
+	if helloWorldId == busyboxId {
+		t.Fatalf("docker.io/hello-world must have different ID than busybox image")
+	}
+
+	// push "hello-world to blocked and additional registry and remove all local images
+	if out, err := d.Cmd("tag", reg2.url+"/busybox", reg1.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to tag image %s: error %v, output %q", reg2.url+"/busybox", err, out)
+	}
+	if out, err := d.Cmd("tag", reg2.url+"/busybox", reg2.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to tag image %s: error %v, output %q", reg2.url+"/busybox", err, out)
+	}
+	if out, err := d.Cmd("push", reg1.url+"/library/hello-world"); err == nil {
+		t.Fatalf("push to blocked registry should have failed, output: %q", out)
+	}
+	if out, err := d.Cmd("push", reg2.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to push image %s: error %v, output %q", reg2.url+"/library/hello-world", err, out)
+	}
+	toRemove := []string{reg1.url + "/library/hello-world", reg2.url + "/library/hello-world", "docker.io/hello-world", reg2.url + "/busybox"}
+	if out, err := d.Cmd("rmi", toRemove...); err != nil {
+		t.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
+	}
+	d.getAndTestImageEntry(t, 0, "", "")
+
+	// try to pull "library/hello-world" from blocked registry
+	if out, err := d.Cmd("pull", reg1.url+"/library/hello-world"); err == nil {
+		t.Fatalf("pull of library/hello-world from additional registry should have failed, output: %q", out)
+	}
+
+	// now pull the "library/hello-world" from additional registry
+	if _, err := d.Cmd("pull", reg2.url+"/library/hello-world"); err != nil {
+		t.Fatalf("we should have been able to pull library/hello-world from \"%s\": %v", reg2.url, err)
+	}
+	d.getAndTestImageEntry(t, 1, reg2.url+"/library/hello-world", busyboxId)
+
+	logDone("pull - image from blocked registry")
 }

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -16,7 +16,7 @@ import (
 func TestPushBusyboxImage(t *testing.T) {
 	defer setupRegistry(t)()
 
-	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
+	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURLs[0])
 	// tag the image to upload it tot he private registry
 	tagCmd := exec.Command(dockerBinary, "tag", "busybox", repoName)
 	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
@@ -43,7 +43,7 @@ func TestPushUnprefixedRepo(t *testing.T) {
 func TestPushUntagged(t *testing.T) {
 	defer setupRegistry(t)()
 
-	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
+	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURLs[0])
 
 	expected := "No tags to push"
 	pushCmd := exec.Command(dockerBinary, "push", repoName)
@@ -58,7 +58,7 @@ func TestPushUntagged(t *testing.T) {
 func TestPushBadTag(t *testing.T) {
 	defer setupRegistry(t)()
 
-	repoName := fmt.Sprintf("%v/dockercli/busybox:latest", privateRegistryURL)
+	repoName := fmt.Sprintf("%v/dockercli/busybox:latest", privateRegistryURLs[0])
 
 	expected := "does not exist"
 	pushCmd := exec.Command(dockerBinary, "push", repoName)
@@ -73,9 +73,9 @@ func TestPushBadTag(t *testing.T) {
 func TestPushMultipleTags(t *testing.T) {
 	defer setupRegistry(t)()
 
-	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
-	repoTag1 := fmt.Sprintf("%v/dockercli/busybox:t1", privateRegistryURL)
-	repoTag2 := fmt.Sprintf("%v/dockercli/busybox:t2", privateRegistryURL)
+	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURLs[0])
+	repoTag1 := fmt.Sprintf("%v/dockercli/busybox:t1", privateRegistryURLs[0])
+	repoTag2 := fmt.Sprintf("%v/dockercli/busybox:t2", privateRegistryURLs[0])
 	// tag the image to upload it tot he private registry
 	tagCmd1 := exec.Command(dockerBinary, "tag", "busybox", repoTag1)
 	if out, _, err := runCommandWithOutput(tagCmd1); err != nil {
@@ -98,7 +98,7 @@ func TestPushMultipleTags(t *testing.T) {
 func TestPushInterrupt(t *testing.T) {
 	defer setupRegistry(t)()
 
-	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
+	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURLs[0])
 	// tag the image to upload it tot he private registry
 	tagCmd := exec.Command(dockerBinary, "tag", "busybox", repoName)
 	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
@@ -127,7 +127,7 @@ func TestPushInterrupt(t *testing.T) {
 
 func TestPushEmptyLayer(t *testing.T) {
 	defer setupRegistry(t)()
-	repoName := fmt.Sprintf("%v/dockercli/emptylayer", privateRegistryURL)
+	repoName := fmt.Sprintf("%v/dockercli/emptylayer", privateRegistryURLs[0])
 	emptyTarball, err := ioutil.TempFile("", "empty_tarball")
 	if err != nil {
 		t.Fatalf("Unable to create test file: %v", err)

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -14,7 +14,7 @@ var (
 	registryImageName = "registry"
 
 	// the private registry to use for tests
-	privateRegistryURL = "127.0.0.1:5000"
+	privateRegistryURLs = []string{"127.0.0.1:5000", "127.0.0.1:5001"}
 
 	dockerBasePath       = "/var/lib/docker"
 	execDriverPath       = dockerBasePath + "/execdriver/native"
@@ -39,7 +39,7 @@ func init() {
 		registryImageName = registryImage
 	}
 	if registry := os.Getenv("REGISTRY_URL"); registry != "" {
-		privateRegistryURL = registry
+		privateRegistryURLs[0] = registry
 	}
 	workingDirectory, _ = os.Getwd()
 }

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -16,6 +16,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -33,6 +34,10 @@ type Daemon struct {
 	storageDriver  string
 	execDriver     string
 	wait           chan error
+}
+
+type LocalImageEntry struct {
+	name, tag, id string
 }
 
 // NewDaemon returns a Daemon instance to be used for testing.
@@ -263,6 +268,88 @@ func (d *Daemon) Cmd(name string, arg ...string) (string, error) {
 	c := exec.Command(dockerBinary, args...)
 	b, err := c.CombinedOutput()
 	return string(b), err
+}
+
+func (d *Daemon) buildImageWithOut(name, dockerfile string, useCache bool) (string, string, error) {
+	args := []string{"--host", d.sock(), "build", "-t", name}
+	if !useCache {
+		args = append(args, "--no-cache")
+	}
+	args = append(args, "-")
+	c := exec.Command(dockerBinary, args...)
+	c.Stdin = strings.NewReader(dockerfile)
+	out, err := c.CombinedOutput()
+	if err != nil {
+		return "", string(out), fmt.Errorf("failed to build the image: %s", out)
+	}
+	id, err := d.inspectField(name, "Id")
+	if err != nil {
+		return "", string(out), err
+	}
+	return id, string(out), nil
+}
+
+// List images of given Docker daemon and return it in a map[repoName]=*LocaleImageEntry.
+func (d *Daemon) getImages(t *testing.T) map[string]*LocalImageEntry {
+	reImageEntry := regexp.MustCompile(`(?m)^([[:alnum:]/.:_-]+)\s+(\w+)\s+([a-fA-F0-9]+)\s+`)
+	result := make(map[string]*LocalImageEntry)
+
+	out, err := d.Cmd("images")
+	if err != nil {
+		t.Fatalf("failed to list images: %v", err)
+	}
+	matches := reImageEntry.FindAllStringSubmatch(out, -1)
+	if matches != nil {
+		for i, match := range matches {
+			if i < 1 && match[1] == "REPOSITORY" {
+				continue // skip header
+			}
+			result[match[1]] = &LocalImageEntry{match[1], match[2], match[3]}
+		}
+	}
+	return result
+}
+
+// List images of given Docker daemon and assert expected values. Unless
+// expectedImageCount is negative, assert the number of images of Docker
+// daemon. Unless repoName is empty, assert it exists and return its matching
+// LocalImageEntry. Unless expectedImageId is empty, assert that image ID of
+// given repoName matches this one.
+func (d *Daemon) getAndTestImageEntry(t *testing.T, expectedImageCount int, repoName, expectedImageId string) *LocalImageEntry {
+	images := d.getImages(t)
+	if expectedImageCount >= 0 && len(images) != expectedImageCount {
+		switch expectedImageCount {
+		case 0:
+			t.Fatalf("expected empty local image database, got %d images", len(images))
+		case 1:
+			t.Fatalf("expected exactly 1 local image, got %d", len(images))
+		default:
+			t.Fatalf("expected exactly %d local images, got %d", expectedImageCount, len(images))
+		}
+	}
+	if repoName != "" {
+		if img, ok := images[repoName]; !ok {
+			keys := make([]string, 0, len(images))
+			for k := range images {
+				keys = append(keys, k)
+			}
+			t.Fatalf("%s missing in list of images: %v", repoName, keys)
+		} else if expectedImageId != "" && img.id != expectedImageId {
+			t.Fatalf("image ID of %s does not match expected (%s != %s)", repoName, img.id, expectedImageId)
+		} else {
+			return img
+		}
+	}
+	return nil
+}
+
+func (d *Daemon) inspectField(name, field string) (string, error) {
+	format := fmt.Sprintf("{{.%s}}", field)
+	out, err := d.Cmd("inspect", "-f", format, name)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect %s: %s", name, out)
+	}
+	return strings.TrimSpace(out), nil
 }
 
 func daemonHost() string {
@@ -877,8 +964,8 @@ func readContainerFile(containerId, filename string) ([]byte, error) {
 	return content, nil
 }
 
-func setupRegistry(t *testing.T) func() {
-	reg, err := newTestRegistryV2(t)
+func setupAndGetRegistryAt(t *testing.T, url string) *testRegistryV2 {
+	reg, err := newTestRegistryV2At(t, url)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -895,6 +982,11 @@ func setupRegistry(t *testing.T) func() {
 		t.Fatal("Timeout waiting for test registry to become available")
 	}
 
+	return reg
+}
+
+func setupRegistry(t *testing.T) func() {
+	reg := setupAndGetRegistryAt(t, privateRegistryURLs[0])
 	return func() { reg.Close() }
 }
 

--- a/integration-cli/registry.go
+++ b/integration-cli/registry.go
@@ -14,10 +14,11 @@ const v2binary = "registry-v2"
 
 type testRegistryV2 struct {
 	cmd *exec.Cmd
+	url string
 	dir string
 }
 
-func newTestRegistryV2(t *testing.T) (*testRegistryV2, error) {
+func newTestRegistryV2At(t *testing.T, url string) (*testRegistryV2, error) {
 	template := `version: 0.1
 loglevel: debug
 storage:
@@ -34,7 +35,7 @@ http:
 	if err != nil {
 		return nil, err
 	}
-	if _, err := fmt.Fprintf(config, template, tmp, privateRegistryURL); err != nil {
+	if _, err := fmt.Fprintf(config, template, tmp, url); err != nil {
 		os.RemoveAll(tmp)
 		return nil, err
 	}
@@ -49,13 +50,18 @@ http:
 	}
 	return &testRegistryV2{
 		cmd: cmd,
+		url: url,
 		dir: tmp,
 	}, nil
 }
 
+func newTestRegistryV2(t *testing.T) (*testRegistryV2, error) {
+	return newTestRegistryV2At(t, privateRegistryURLs[0])
+}
+
 func (t *testRegistryV2) Ping() error {
 	// We always ping through HTTP for our test registry.
-	resp, err := http.Get(fmt.Sprintf("http://%s/v2/", privateRegistryURL))
+	resp, err := http.Get(fmt.Sprintf("http://%s/v2/", t.url))
 	if err != nil {
 		return err
 	}

--- a/registry/config.go
+++ b/registry/config.go
@@ -430,7 +430,11 @@ func (config *ServiceConfig) NewRepositoryInfo(reposName string) (*RepositoryInf
 		repoInfo.LocalName = repoInfo.Index.Name + "/" + normalizedName
 	} else {
 		// *TODO: Decouple index name from hostname (via registry configuration?)
-		repoInfo.LocalName = repoInfo.Index.Name + "/" + repoInfo.RemoteName
+		if repoInfo.Index.Name != "" {
+			repoInfo.LocalName = repoInfo.Index.Name + "/" + repoInfo.RemoteName
+		} else {
+			repoInfo.LocalName = repoInfo.RemoteName
+		}
 	}
 	repoInfo.CanonicalName = repoInfo.LocalName
 	return repoInfo, nil


### PR DESCRIPTION
The fix corrects repository naming when default registry is missing (public
registry is blocked and no additional is specified). In this situation, built
images would be named `/<repoName>` - note the leading slash. This patch makes
such images names without any prefix (just `<repoName>`).