### PR TITLE
Make pulls in build process behave as regular pulls

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -565,7 +565,6 @@ func postImagesCreate(eng *engine.Engine, version version.Version, w http.Respon
 		job.SetenvBool("parallel", version.GreaterThan("1.3"))
 		job.SetenvJson("metaHeaders", metaHeaders)
 		job.SetenvJson("authConfig", authConfig)
-		job.SetenvBool("protectOfficialRegistry", false)
 	} else { //import
 		if tag == "" {
 			repo, tag = parsers.ParseRepositoryTag(repo)

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -440,7 +440,6 @@ func (b *Builder) pullImage(name string) (*imagepkg.Image, error) {
 	job.SetenvBool("json", b.StreamFormatter.Json())
 	job.SetenvBool("parallel", true)
 	job.SetenvJson("authConfig", pullRegistryAuth)
-	job.SetenvBool("protectOfficialRegistry", true)
 	job.Stdout.Add(ioutils.NopWriteCloser(b.OutOld))
 	if err := job.Run(); err != nil {
 		return nil, err

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -37,11 +37,6 @@ func (s *TagStore) CmdRegistryPull(job *engine.Job) engine.Status {
 	if len(registry.RegistryList) == 0 {
 		return job.Errorf("No configured registry to pull from.")
 	}
-	if job.GetenvBool("protectOfficialRegistry") {
-		// We must ensure that registry missing hostname will be pulled from
-		// official one, if the `protectOfficialRegistry` tells us so.
-		return doPull(fmt.Sprintf("%s/%s", registry.INDEXNAME, tmp))
-	}
 	for _, r := range registry.RegistryList {
 		// Prepend the index name to the image/repository.
 		if status = doPull(fmt.Sprintf("%s/%s", r, tmp)); status == engine.StatusOK {

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -987,8 +987,8 @@ func readContainerFileWithExec(containerId, filename string) ([]byte, error) {
 	return []byte(out), err
 }
 
-func setupRegistry(t *testing.T) func() {
-	reg, err := newTestRegistryV2(t)
+func setupAndGetRegistryAt(t *testing.T, url string) *testRegistryV2 {
+	reg, err := newTestRegistryV2At(t, url)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Currently *FROM* statement treats repositories without registry name
prefix as belonging to public registry while pull tries to find it in
additional registries first.

This patch reverts to older behaviour where *FROM* statement treated its
argument the same way as regular `docker pull` would (additional
registries are queried before a public one).

Signed-off-by: Michal Minar <miminar@redhat.com>