### PR TITLE
Allow image lookups with unqualified repository names

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3241,3 +3241,64 @@ func TestRunVolumesFromRestartAfterRemoved(t *testing.T) {
 
 	logDone("run - can restart a volumes-from container after producer is removed")
 }
+
+func TestRunWithAdditionalRegistry(t *testing.T) {
+	reg := setupAndGetRegistryAt(t, privateRegistryURLs[0])
+	defer reg.Close()
+	d := NewDaemon(t)
+	if err := d.StartWithBusybox("--add-registry=" + reg.url); err != nil {
+		t.Fatalf("we should have been able to start the daemon with passing add-registry=%s: %v", reg.url, err)
+	}
+	defer d.Stop()
+
+	busyboxId := d.getAndTestImageEntry(t, 1, reg.url+"/busybox", "").id
+
+	// try to run fully qualified image
+	if out, err := d.Cmd("run", "-t", reg.url+"/busybox", "sh", "-c", "echo foo"); err != nil {
+		t.Fatalf("failed to run %s/busybox image: %v, output: %s", reg.url, err, out)
+	} else if strings.TrimSpace(out) != "foo" {
+		t.Fatalf("got unexpected output: %q", out)
+	}
+
+	// try to run unqualified
+	if out, err := d.Cmd("run", "-t", "busybox", "sh", "-c", "echo foo"); err != nil {
+		t.Fatalf("failed to run busybox image: %v, output: %s", err, out)
+	} else if out != "foo\r\n" {
+		t.Fatalf("got unexpected output: %q", out)
+	}
+
+	// try to run hello world from additional registry
+	if out, err := d.Cmd("run", "-t", reg.url+"/library/hello-world", "sh", "-c", "echo foo"); err == nil {
+		t.Fatalf("running container from image %s/library/hello-world should have failed; output: %s", reg.url, out)
+	}
+
+	// try to run hello-world from official registry
+	if out, err := d.Cmd("run", "-t", "library/hello-world"); err != nil {
+		t.Fatalf("failed to run library/hello-world image: %v, output: %s", err, out)
+	} else if strings.HasSuffix(strings.TrimSpace(out), "foo") {
+		t.Fatalf("got unexpected output")
+	}
+	d.getAndTestImageEntry(t, 2, "docker.io/hello-world", "")
+
+	// push busybox to additional registry as "library/hello-world" and remove all local images
+	if out, err := d.Cmd("tag", reg.url+"/busybox", reg.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to tag image %s: error %v, output %q", reg.url+"/busybox", err, out)
+	}
+	if out, err := d.Cmd("push", reg.url+"/library/hello-world"); err != nil {
+		t.Fatalf("failed to push image %s: error %v, output %q", reg.url+"/library/hello-world", err, out)
+	}
+	args := []string{"-f", "busybox", "hello-world", "library/hello-world"}
+	if out, err := d.Cmd("rmi", args...); err != nil {
+		time.Sleep(10000 * time.Minute)
+		t.Fatalf("failed to remove images %v: %v, output: %s", args[1:], err, out)
+	}
+	d.getAndTestImageEntry(t, 0, "", "")
+
+	// now try to run unqualified hello-world again - this time we should pull from additional registry
+	if out, err := d.Cmd("run", "-t", "library/hello-world", "sh", "-c", "echo foo"); err != nil {
+		t.Fatalf("failed to run library/hello-world image: %v, output: %s", err, out)
+	} else if !strings.HasSuffix(strings.TrimSpace(out), "\nfoo") {
+		t.Fatalf("got unexpected output: %q", out)
+	}
+	d.getAndTestImageEntry(t, 1, reg.url+"/library/hello-world", busyboxId)
+}

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -984,9 +984,9 @@ func readContainerFileWithExec(containerId, filename string) ([]byte, error) {
 	return []byte(out), err
 }
 
-func setupRegistry(t *testing.T) func() {
+func setupAndGetRegistryAt(t *testing.T, url string) *testRegistryV2 {
 	testRequires(t, RegistryHosting)
-	reg, err := newTestRegistryV2(t)
+	reg, err := newTestRegistryV2At(t, url)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This fixes a bug, where run command does not found local image, pulls it
and then fails to run it because internally it has been fully qualified
e.g.:

    $ docker run -it docker.io/fedora bash
    Unable to find image 'fedora:latest' locally
    Pulling repository registry.access.redhat.com/fedora
    latest: Pulling from docker.io/fedora
    511136ea3c5a: Already exists
    00a0c78eeb6d: Already exists
    Status: Image is up to date for docker.io/fedora:latest
    FATA[0001] Error response from daemon: No such image: fedora (tag: latest)

Note that docker.io/fedora was already pulled before issuing above
command.


    bash-4.3#

Because the image is found immediately.