### PR TITLE
Improved searching experience

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2049,13 +2049,16 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 
 	v := url.Values{}
 	v.Set("term", cmd.Arg(0))
+	if *noIndex {
+		v.Set("noIndex", "1")
+	}
 
 	body, _, err := readBody(cli.call("GET", "/images/search?"+v.Encode(), nil, true))
 
 	if err != nil {
 		return err
 	}
-	outs := engine.NewTable("star_count", 0)
+	outs := engine.NewTable("index_name", 0)
 	if _, err := outs.ReadListFrom(body); err != nil {
 		return err
 	}

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -2038,6 +2039,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 func (cli *DockerCli) CmdSearch(args ...string) error {
 	cmd := cli.Subcmd("search", "TERM", "Search the Docker Hub for images", true)
 	noTrunc := cmd.Bool([]string{"#notrunc", "-no-trunc"}, false, "Don't truncate output")
+	noIndex := cmd.Bool([]string{"#noindex", "-no-index"}, false, "Don't prepend index to output")
 	trusted := cmd.Bool([]string{"#t", "#trusted", "#-trusted"}, false, "Only show trusted builds")
 	automated := cmd.Bool([]string{"-automated"}, false, "Only show automated builds")
 	stars := cmd.Int([]string{"s", "#stars", "-stars"}, 0, "Only displays with at least x stars")
@@ -2058,17 +2060,42 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 		return err
 	}
 	w := tabwriter.NewWriter(cli.out, 10, 1, 3, ' ', 0)
-	fmt.Fprintf(w, "NAME\tDESCRIPTION\tSTARS\tOFFICIAL\tAUTOMATED\n")
+
+	if !*noIndex {
+		fmt.Fprintf(w, "INDEX\tNAME\tDESCRIPTION\tSTARS\tOFFICIAL\tAUTOMATED\n")
+	} else {
+		fmt.Fprintf(w, "NAME\tDESCRIPTION\tSTARS\tOFFICIAL\tAUTOMATED\n")
+	}
 	for _, out := range outs.Data {
 		if ((*automated || *trusted) && (!out.GetBool("is_trusted") && !out.GetBool("is_automated"))) || (*stars > out.GetInt("star_count")) {
 			continue
 		}
+		indexName := out.Get("index_name")
+		if !*noTrunc {
+			// Shorten index name to DOMAIN.TLD unless --no-trunc is given.
+			if host, _, err := net.SplitHostPort(indexName); err == nil {
+				indexName = host
+			}
+			// do not shorten ip address
+			if net.ParseIP(indexName) == nil {
+				// shorten index name just to the last 2 components (`DOMAIN.TLD`)
+				indexNameSubStrings := strings.Split(indexName, ".")
+				if len(indexNameSubStrings) > 2 {
+					indexName = strings.Join(indexNameSubStrings[len(indexNameSubStrings)-2:], ".")
+				}
+			}
+		}
+
 		desc := strings.Replace(out.Get("description"), "\n", " ", -1)
 		desc = strings.Replace(desc, "\r", " ", -1)
 		if !*noTrunc && len(desc) > 45 {
 			desc = utils.Trunc(desc, 42) + "..."
 		}
-		fmt.Fprintf(w, "%s\t%s\t%d\t", out.Get("name"), desc, out.GetInt("star_count"))
+		if !*noIndex {
+			fmt.Fprintf(w, "%s:\t%s/%s\t%s\t%d\t", indexName, out.Get("registry_name"), out.Get("name"), desc, out.GetInt("star_count"))
+		} else {
+			fmt.Fprintf(w, "%s/%s\t%s\t%d\t", out.Get("registry_name"), out.Get("name"), desc, out.GetInt("star_count"))
+		}
 		if out.GetBool("is_official") {
 			fmt.Fprint(w, "[OK]")
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -628,6 +628,7 @@ func getImagesSearch(eng *engine.Engine, version version.Version, w http.Respons
 	var job = eng.Job("search", r.Form.Get("term"))
 	job.SetenvJson("metaHeaders", metaHeaders)
 	job.SetenvJson("authConfig", authConfig)
+	job.SetenvBool("noIndex", r.Form.Get("noIndex") == "1")
 	streamJSON(job, w, false)
 
 	return job.Run()

--- a/docs/man/docker-search.1.md
+++ b/docs/man/docker-search.1.md
@@ -26,7 +26,11 @@ is automated.
    Only show automated builds. The default is *false*.
 
 **--help**
-  Print usage statement
+   Print usage statement
+
+**--no-index**=*true*|*false*
+   Do not include index name in output. Sort results primarily by registry
+   name.
 
 **--no-trunc**=*true*|*false*
    Don't truncate output. The default is *false*.
@@ -42,11 +46,11 @@ Search the registry for the term 'fedora' and only display those images
 ranked 3 or higher:
 
     $ sudo docker search -s 3 fedora
-    NAME                  DESCRIPTION                                    STARS OFFICIAL  AUTOMATED
-    mattdm/fedora         A basic Fedora image corresponding roughly...  50
-    fedora                (Semi) Official Fedora base image.             38
-    mattdm/fedora-small   A small Fedora image on which to build. Co...  8
-    goldmann/wildfly      A WildFly application server running on a ...  3               [OK]
+    INDEX      NAME                            DESCRIPTION                                    STARS OFFICIAL  AUTOMATED
+    docker.io  docker.io/mattdm/fedora         A basic Fedora image corresponding roughly...  50
+    docker.io  docker.io/fedora                (Semi) Official Fedora base image.             38
+    docker.io  docker.io/mattdm/fedora-small   A small Fedora image on which to build. Co...  8
+    docker.io  docker.io/goldmann/wildfly      A WildFly application server running on a ...  3               [OK]
 
 ## Search the registry for automated images
 
@@ -54,9 +58,9 @@ Search the registry for the term 'fedora' and only display automated images
 ranked 1 or higher:
 
     $ sudo docker search -s 1 -t fedora
-    NAME               DESCRIPTION                                     STARS OFFICIAL  AUTOMATED
-    goldmann/wildfly   A WildFly application server running on a ...   3               [OK]
-    tutum/fedora-20    Fedora 20 image with SSH access. For the r...   1               [OK]
+    INDEX      NAME                         DESCRIPTION                                     STARS OFFICIAL  AUTOMATED
+    docker.io  docker.io/goldmann/wildfly   A WildFly application server running on a ...   3               [OK]
+    docker.io  docker.io/tutum/fedora-20    Fedora 20 image with SSH access. For the r...   1               [OK]
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -1364,23 +1364,29 @@ Search for an image on [Docker Hub](https://hub.docker.com).
         [
                 {
                     "description": "",
+                    "index_name" : "docker.io"
                     "is_official": false,
                     "is_automated": false,
                     "name": "wma55/u1210sshd",
+                    "registry_name" : "docker.io",
                     "star_count": 0
                 },
                 {
                     "description": "",
+                    "index_name" : "docker.io"
                     "is_official": false,
                     "is_automated": false,
                     "name": "jdswinbank/sshd",
+                    "registry_name" : "docker.io",
                     "star_count": 0
                 },
                 {
                     "description": "",
+                    "index_name" : "docker.io"
                     "is_official": false,
                     "is_automated": false,
                     "name": "vgauthier/sshd",
+                    "registry_name" : "docker.io",
                     "star_count": 0
                 }
         ...
@@ -1389,6 +1395,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 Query Parameters:
 
 -   **term** – term to search
+-   **noIndex** - whether to include `index_name` in result respons and sort results with it
 
 Status Codes:
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/engine"
 	"github.com/docker/docker/utils"
 )
 
@@ -894,4 +895,170 @@ func TestIsSecureIndex(t *testing.T) {
 			t.Errorf("isSecureIndex failed for %q %v, expected %v got %v", tt.addr, tt.insecureRegistries, tt.expected, sec)
 		}
 	}
+}
+
+type TestRegistryInfo struct {
+	IndexName    string `json:"index_name"`
+	RegistryName string `json:"registry_name"`
+	Name         string `json:"name"`
+	StarCount    int    `json:"star_count"`
+	IsOfficial   bool   `json:"is_official"`
+	IsTrusted    bool   `json:"is_trusted"`
+	Description  string `json:"description"`
+}
+
+var sortSearchResultsCases = []TestRegistryInfo{
+	{"docker.io", "isv.company.ltd", "misc/image", 10, false, false, "Some custom image."},
+	{"docker.io", "isv.company.ltd", "custom/image", 10, false, false, "Some custom image."},
+	{"index.company.ltd", "registry.stage.company.ltd", "centos", 6, false, true, "Another CentOS"},
+	{"docker.io", "docker.io", "custom/image", 5, false, false, "Some custom image from docker registry."},
+	{"127.0.0.1:5000", "127.0.0.1:5000", "custom/image", 0, false, false, "Image from private repo."},
+	{"docker.io", "registry.company.ltd", "centos", 0, false, true, "Second hand CentOS"},
+	{"docker.io", "docker.io", "user/app", 0, false, false, "Some user app."},
+	{"docker.io", "docker.io", "user/app1", 5, false, false, "Some user app."},
+	{"docker.io", "docker.io", "user/app2", 2, false, false, "Some user app."},
+	{"127.0.0.1:5000", "isv.company.ltd", "custom/image", 11, false, false, "Image from private repo."},
+	{"docker.io", "docker.io", "user/app3", 3, false, false, "Some user app."},
+	{"index.company.ltd", "registry.company.ltd", "centos", 11, false, true, "CentOS."},
+	{"docker.io", "docker.io", "fedora/apache", 0, true, true, "Official apache"},
+	{"docker.io", "registry.stage.company.ltd", "centos", 11, false, true, "CentOS from another registry."},
+	{"docker.io", "isv.another.comp.ltd", "custom/image", 9, false, false, "Custom image."},
+	{"index.company.ltd", "isv.company.ltd", "custom/image", 10, false, false, "Some custom image."},
+	{"index.company.ltd", "isv.company.ltd", "custom/image", 11, false, false, "Some custom image."},
+	{"127.0.0.1:5000", "127.0.0.1:5000", "centos", 0, false, false, "CentOS from private repo."},
+	{"127.0.0.1:5000", "docker.io", "user/app2", 0, false, false, "User app from private registry."},
+}
+
+// `sortedEntriesMapping` maps new position in the list to original one after
+// the sort. `duplicates` is a list of duplicate entries that should be removed
+// after the call to `removeSearchDuplicates`. May be null if sorting with
+// index.
+func doTestSortSearchResults(t *testing.T, withIndex bool, sortedEntriesMapping map[int]int, duplicates []int) {
+	var unsortedEntries []*engine.Env
+	outs := engine.NewTableWithCmpFunc(getSearchResultsCmpFunc(withIndex), len(sortSearchResultsCases))
+	for _, tr := range sortSearchResultsCases {
+		entry := &engine.Env{}
+		entry.Import(tr)
+		outs.Add(entry)
+		unsortedEntries = append(unsortedEntries, entry)
+	}
+
+	outs.Sort()
+
+	for i, entry := range unsortedEntries {
+		if newPos, ok := sortedEntriesMapping[i]; !ok {
+			t.Fatalf("sortedEntriesMapping is incomplete (%d index is missing)", i)
+		} else if newPos > len(outs.Data) {
+			t.Fatalf("expected position for entry %d is out of range (%d >= %d)", i, newPos, len(outs.Data))
+		}
+		if outs.Data[sortedEntriesMapping[i]] != entry {
+			j := 0
+			for ; j < len(outs.Data); j++ {
+				if outs.Data[j] == entry {
+					break
+				}
+			}
+			if j >= len(unsortedEntries) {
+				t.Fatalf("sortedEntriesMapping is incomplete")
+			}
+			t.Errorf("Sort failed, item %v (orig. pos=%d) expected on position %d, not %d.", *entry, i, sortedEntriesMapping[i], j)
+		}
+	}
+
+	if !withIndex {
+		sorted := removeSearchDuplicates(outs.Data)
+		if len(sorted) != len(unsortedEntries)-len(duplicates) {
+			t.Errorf("Expected %d items in output table after removing duplicates, not %d.",
+				len(unsortedEntries)-len(duplicates), len(sorted))
+		}
+
+		for i, entry := range unsortedEntries {
+			isRedundant := false
+			for j := range duplicates {
+				if i == duplicates[j] {
+					isRedundant = true
+					break
+				}
+			}
+			found := false
+			j := 0
+			for ; j < len(sorted); j++ {
+				if entry == sorted[j] {
+					found = true
+					break
+				}
+			}
+			if found && isRedundant {
+				t.Errorf("Entry %v (orig. pos=%d, new pos=%d) is redundant and should have been removed.", *entry, i, j)
+			} else if !found && !isRedundant {
+				t.Errorf("Entry %v (orig. pos=%d) should have stayed in sorted results.", *entry, i)
+			}
+		}
+	}
+}
+
+func TestSortSearchResultsWithIndex(t *testing.T) {
+	sortedEntriesMapping := map[int]int{
+		0:  6,
+		1:  5,
+		2:  18,
+		3:  8,
+		4:  2,
+		5:  14,
+		6:  13,
+		7:  9,
+		8:  11,
+		9:  0,
+		10: 10,
+		11: 16,
+		12: 12,
+		13: 4,
+		14: 7,
+		15: 17,
+		16: 15,
+		17: 1,
+		18: 3,
+	}
+
+	// Should have not effect.
+	RegistryList = append([]string{"index.company.ltd"}, RegistryList...)
+	defer func() {
+		RegistryList = []string{INDEXNAME}
+	}()
+
+	doTestSortSearchResults(t, true, sortedEntriesMapping, nil)
+}
+
+func TestSortSearchResultsWithoutIndex(t *testing.T) {
+	sortedEntriesMapping := map[int]int{
+		0:  14,
+		1:  13, // duplicate with 9, 15, 16
+		2:  18, // duplicate with 13
+		3:  2,
+		4:  1,
+		5:  16, // duplicate with 11
+		6:  7,
+		7:  3,
+		8:  5,
+		9:  10, // duplicate with 1, 15, 16
+		10: 4,
+		11: 15, // duplicate with 5
+		12: 6,
+		13: 17, //duplicate with 2
+		14: 9,
+		15: 12, // duplicate with 1, 9, 16
+		16: 11, // duplicate with 1, 9, 15
+		17: 0,
+		18: 8,
+	}
+
+	duplicates := []int{1, 5, 9, 13, 15}
+
+	// Duplicates having index nearest the first item in this list should have higher preference.
+	RegistryList = append([]string{"index.company.ltd"}, RegistryList...)
+	defer func() {
+		RegistryList = []string{INDEXNAME}
+	}()
+
+	doTestSortSearchResults(t, false, sortedEntriesMapping, duplicates)
 }

--- a/registry/service.go
+++ b/registry/service.go
@@ -83,56 +83,73 @@ func (s *Service) Auth(job *engine.Job) engine.Status {
 	return engine.StatusOK
 }
 
-// Compare two items in the result table of search command.
-// First compare the index we found the result in. Second compare their rating. Then compare their fully qualified name (registry/name).
-func cmpSearchResults(fst, snd *engine.Env) int {
-	indA := fst.Get("index_name")
-	indB := snd.Get("index_name")
-	switch {
-	case indA < indB:
-		return -1
-	case indA > indB:
-		return 1
-	}
+// Factory for search result comparison function. Either it takes index name
+// into consideration or not.
+func getSearchResultsCmpFunc(withIndex bool) func(fst, snd *engine.Env) int {
+	cmpByStarCount := func(fst, snd *engine.Env) int {
+		starsA := fst.Get("star_count")
+		starsB := snd.Get("star_count")
 
-	starsA := fst.Get("star_count")
-	starsB := snd.Get("star_count")
-
-	intA, errA := strconv.ParseInt(starsA, 10, 64)
-	intB, errB := strconv.ParseInt(starsB, 10, 64)
-	if errA == nil && errB == nil {
+		intA, errA := strconv.ParseInt(starsA, 10, 64)
+		intB, errB := strconv.ParseInt(starsB, 10, 64)
+		if errA == nil && errB == nil {
+			switch {
+			case intA > intB:
+				return -1
+			case intA < intB:
+				return 1
+			}
+		}
 		switch {
-		case intA > intB:
+		case starsA > starsB:
 			return -1
-		case intA < intB:
+		case starsA < starsB:
 			return 1
 		}
-	}
-	switch {
-	case starsA > starsB:
-		return -1
-	case starsA < starsB:
-		return 1
+		return 0
 	}
 
-	regA := fst.Get("registry_name")
-	regB := snd.Get("registry_name")
-	switch {
-	case regA < regB:
-		return -1
-	case regA > regB:
-		return 1
+	cmpStringField := func(field string, fst, snd *engine.Env) int {
+		valA := fst.Get(field)
+		valB := snd.Get(field)
+		switch {
+		case valA < valB:
+			return -1
+		case valA > valB:
+			return 1
+		}
+		return 0
 	}
 
-	nameA := fst.Get("name")
-	nameB := snd.Get("name")
-	switch {
-	case nameA < nameB:
-		return -1
-	case nameA > nameB:
-		return 1
+	// Compare two items in the result table of search command. First compare
+	// the index we found the result in. Second compare their rating. Then
+	// compare their fully qualified name (registry/name).
+	cmpFunc := func(fst, snd *engine.Env) int {
+		if withIndex {
+			if res := cmpStringField("index_name", fst, snd); res != 0 {
+				return res
+			}
+			if byStarCount := cmpByStarCount(fst, snd); byStarCount != 0 {
+				return byStarCount
+			}
+		}
+		if res := cmpStringField("registry_name", fst, snd); res != 0 {
+			return res
+		}
+		if !withIndex {
+			if byStarCount := cmpByStarCount(fst, snd); byStarCount != 0 {
+				return byStarCount
+			}
+		}
+		if res := cmpStringField("name", fst, snd); res != 0 {
+			return res
+		}
+		if res := cmpStringField("description", fst, snd); res != 0 {
+			return res
+		}
+		return 0
 	}
-	return 0
+	return cmpFunc
 }
 
 func searchTerm(job *engine.Job, outs *engine.Table, term string) error {
@@ -142,6 +159,7 @@ func searchTerm(job *engine.Job, outs *engine.Table, term string) error {
 	)
 	job.GetenvJson("authConfig", authConfig)
 	job.GetenvJson("metaHeaders", metaHeaders)
+	noIndex := job.GetenvBool("noIndex")
 
 	repoInfo, err := ResolveRepositoryInfo(job, term)
 	if err != nil {
@@ -165,15 +183,55 @@ func searchTerm(job *engine.Job, outs *engine.Table, term string) error {
 		// If not, assume REGISTRY = INDEX
 		registryName := repoInfo.Index.Name
 		if RepositoryNameHasIndex(result.Name) {
-			registryName, result.Name = splitReposName(result.Name, false)
+			registryName, result.Name = SplitReposName(result.Name, false)
 		}
 		out.Import(result)
 		// Now add the index in which we found the result to the json. (not sure this is really the right place for this)
 		out.Set("registry_name", registryName)
-		out.Set("index_name", repoInfo.Index.Name)
+		if !noIndex {
+			out.Set("index_name", repoInfo.Index.Name)
+		}
 		outs.Add(out)
 	}
 	return nil
+}
+
+// Duplicate entries may occur in result table when omitting index from output because
+// different indexes may refer to same registries.
+func removeSearchDuplicates(data []*engine.Env) (res []*engine.Env) {
+	var prevIndex = 0
+
+	if len(data) > 0 {
+		res = []*engine.Env{data[0]}
+	}
+	for i := 1; i < len(data); i++ {
+		prev := res[prevIndex]
+		curr := data[i]
+		if prev.Get("registry_name") == curr.Get("registry_name") && prev.Get("name") == curr.Get("name") {
+			// Repositories are equal, delete one of them.
+			// Find out whose index has higher priority (the lower the number
+			// the higher the priority).
+			var prioPrev, prioCurr int
+			for prioPrev = 0; prioPrev < len(RegistryList); prioPrev++ {
+				if prev.Get("index_name") == RegistryList[prioPrev] {
+					break
+				}
+			}
+			for prioCurr = 0; prioCurr < len(RegistryList); prioCurr++ {
+				if curr.Get("index_name") == RegistryList[prioCurr] {
+					break
+				}
+			}
+			if prioPrev > prioCurr || (prioPrev == prioCurr && prev.Get("star_count") < curr.Get("star_count")) {
+				// replace previous entry with current one
+				res[prevIndex] = curr
+			} // otherwise keep previous entry
+		} else {
+			prevIndex++
+			res = append(res, curr)
+		}
+	}
+	return
 }
 
 // Search queries the public registry for images matching the specified
@@ -187,21 +245,24 @@ func searchTerm(job *engine.Job, outs *engine.Table, term string) error {
 //
 //	'metaHeaders': extra HTTP headers to include in the request to the registry.
 //		The headers should be passed as a json-encoded dictionary.
+//	'noIndex': boolean parameter saying wether to include index in results or
+//		not
 //
 // Output:
 //	Results are sent as a collection of structured messages (using engine.Table).
 //	Each result is sent as a separate message.
 //	Results are ordered by:
-//	    1. registry's index name
-//          2. number of stars on registry
-//          3. registry's name
+//		1. registry's index name
+//		2. number of stars on registry
+//		3. registry's name
 func (s *Service) Search(job *engine.Job) engine.Status {
 	if n := len(job.Args); n != 1 {
 		return job.Errorf("Usage: %s TERM", job.Name)
 	}
 	var (
-		term = job.Args[0]
-		outs = engine.NewTableWithCmpFunc(cmpSearchResults, 0)
+		term    = job.Args[0]
+		noIndex = job.GetenvBool("noIndex")
+		outs    = engine.NewTableWithCmpFunc(getSearchResultsCmpFunc(!noIndex), 0)
 	)
 
 	// helper for concurrent queries
@@ -244,6 +305,9 @@ func (s *Service) Search(job *engine.Job) engine.Status {
 		}
 	}
 	outs.Sort()
+	if noIndex {
+		outs.Data = removeSearchDuplicates(outs.Data)
+	}
 	if _, err := outs.WriteListTo(job.Stdout); err != nil {
 		return job.Error(err)
 	}


### PR DESCRIPTION
- Added index and registry names to json output.
- Added `--no-index` option to avoid listing the index name.
- Changed sorting order to:

  1. sort by `index_name`
  2. sort by `star_count`
  3. sort by `registry_name`
  4. sort by `name`
  5. sort by `description`

- Changed sorting order when index is omitted:

  1. sort by `registry_name`
  2. sort by `star_count`
  3. sort by `name`
  4. sort by `description`