### PR TITLE
Do not prohibit redirects from official registry

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -145,26 +145,6 @@ func (s *TagStore) pullRepository(r *registry.Session, out io.Writer, repoInfo *
 		return err
 	}
 
-	if strings.HasPrefix(repoInfo.LocalName, registry.INDEXNAME+"/") {
-		newEndpoints := []string{}
-		unofficial := []string{}
-		for _, endpoint := range repoData.Endpoints {
-			if parsedURL, err := url.Parse(endpoint); err == nil {
-				if strings.HasSuffix(parsedURL.Host, registry.INDEXNAME) {
-					newEndpoints = append(newEndpoints, endpoint)
-				} else {
-					logrus.Infof("Filtering out endpoint %q pointing out to unofficial registry.", endpoint)
-					unofficial = append(unofficial, strings.Replace(repoInfo.LocalName, registry.INDEXNAME, parsedURL.Host, 1))
-				}
-			}
-		}
-		if len(newEndpoints) == 0 {
-			out.Write(sf.FormatStatus("", " failed"))
-			return fmt.Errorf("Official registry redirects to unofficial for repository %q, please specify it as: %s", repoInfo.LocalName, strings.Join(unofficial, " or "))
-		}
-		repoData.Endpoints = newEndpoints
-	}
-
 	logrus.Debugf("Retrieving the tag list")
 	tagsList, err := r.GetRemoteTags(repoData.Endpoints, repoInfo.RemoteName, repoData.Tokens)
 	if err != nil {


### PR DESCRIPTION
If public Docker registre redirects to another registry, let's follow it
and accept image being prefixed with `docker.io/`.

Signed-off-by: Michal Minar <miminar@redhat.com>