### PR TITLE
Made push confirmation case-insensitive

### DIFF
--- a/api/client/push.go
+++ b/api/client/push.go
@@ -24,7 +24,7 @@ func (cli *DockerCli) confirmPush() bool {
 		fmt.Fprintln(cli.out, "Nothing pushed.")
 	}
 
-	return answer == "Y"
+	return answer == "Y" || answer == "y"
 }
 
 // CmdPush pushes an image or repository to the registry.

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -197,7 +197,7 @@ func TestLookupImage(t *testing.T) {
 	runCases(testPrivateImageID, digestLookups, true)
 
 	// now make local image fully qualified (`docker.io` will be prepended)
-	store.Set(testLocalImageName, "", testLocalImageID, false, false)
+	store.Tag(testLocalImageName, "", testLocalImageID, false, false)
 	store.Delete(testLocalImageName, "latest")
 
 	if imageCount(store) != 3 {
@@ -409,7 +409,7 @@ func runSetTagCases(t *testing.T, store *TagStore, additionalRegistry string) {
 				if testCase.refIsDigest {
 					err = store.SetDigest(testCase.dest, testCase.destRef, taggedSource, testCase.preserveName)
 				} else {
-					err = store.Set(testCase.dest, testCase.destRef, taggedSource, false, testCase.preserveName)
+					err = store.Tag(testCase.dest, testCase.destRef, taggedSource, false, testCase.preserveName)
 				}
 
 				if err == nil && !testCase.shallSucceed {


### PR DESCRIPTION
Accept both `"y"` and `"Y"` when confirming a push to public registry.