### PR TITLE
Made push confirmation case-insensitive

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1290,7 +1290,7 @@ func (cli *DockerCli) confirmPush() bool {
 		fmt.Fprintln(cli.out, "Nothing pushed.")
 	}
 
-	return answer == "Y"
+	return strings.ToUpper(answer) == "Y"
 }
 
 func (cli *DockerCli) CmdPush(args ...string) error {


### PR DESCRIPTION
Accept both "y" and "Y" when confirming a push to public registry.

Signed-off-by: Michal Minar <miminar@redhat.com>