### PR TITLE
Preserve tag passed on command-line

### DIFF
--- a/graph/tag.go
+++ b/graph/tag.go
@@ -12,7 +12,7 @@ func (s *TagStore) CmdTag(job *engine.Job) engine.Status {
 	if len(job.Args) == 3 {
 		tag = job.Args[2]
 	}
-	if err := s.Set(job.Args[1], tag, job.Args[0], job.GetenvBool("force"), false); err != nil {
+	if err := s.Set(job.Args[1], tag, job.Args[0], job.GetenvBool("force"), true); err != nil {
 		return job.Error(err)
 	}
 	return engine.StatusOK

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -89,7 +89,7 @@ func mkTestTagStore(root string, t *testing.T) *TagStore {
 	if err := store.Set(testPrivateImageName, "", testPrivateImageID, false, true); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.SetDigest(testPrivateImageName, testPrivateImageDigest, testPrivateImageID, false); err != nil {
+	if err := store.SetDigest(testPrivateImageName, testPrivateImageDigest, testPrivateImageID, true); err != nil {
 		t.Fatal(err)
 	}
 	return store

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/common"
-	"github.com/docker/docker/registry"
 )
 
 func TestImagesEnsureImageIsListed(t *testing.T) {
@@ -192,7 +191,7 @@ func TestImagesEnsureDanglingImageOnlyListedOnce(t *testing.T) {
 	containerId1 := strings.TrimSpace(out)
 
 	// tag as foobox
-	c = exec.Command(dockerBinary, "commit", containerId1, registry.IndexServerName()+"/foobox")
+	c = exec.Command(dockerBinary, "commit", containerId1, "foobox")
 	out, _, err = runCommandWithOutput(c)
 	if err != nil {
 		t.Fatalf("error tagging foobox: %s", err)

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -10,8 +10,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-
-	"github.com/docker/docker/registry"
 )
 
 // save a repo using gz compression and try to load it using stdout
@@ -166,7 +164,7 @@ func TestSaveImageId(t *testing.T) {
 		t.Fatalf("failed to tag repo: %s, %v", out, err)
 	}
 
-	idLongCmd := exec.Command(dockerBinary, "images", "-q", "--no-trunc", registry.INDEXNAME+"/"+repoName)
+	idLongCmd := exec.Command(dockerBinary, "images", "-q", "--no-trunc", repoName)
 	out, _, err := runCommandWithOutput(idLongCmd)
 	if err != nil {
 		t.Fatalf("failed to get repo ID: %s, %v", out, err)
@@ -174,7 +172,7 @@ func TestSaveImageId(t *testing.T) {
 
 	cleanedLongImageID := stripTrailingCharacters(out)
 
-	idShortCmd := exec.Command(dockerBinary, "images", "-q", registry.INDEXNAME+"/"+repoName)
+	idShortCmd := exec.Command(dockerBinary, "images", "-q", repoName)
 	out, _, err = runCommandWithOutput(idShortCmd)
 	if err != nil {
 		t.Fatalf("failed to get repo short ID: %s, %v", out, err)

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/engine"
-	"github.com/docker/docker/registry"
 )
 
 func TestCreateNumberHostname(t *testing.T) {
@@ -275,43 +274,27 @@ func TestImagesFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	images := getImages(eng, t, false, "*utest*/*")
-	repoTags := images[0].RepoTags
-	if len(images[0].RepoTags) != 1 {
-		t.Fatal("incorrect number of matches returned")
-	}
-	expected := "utest:5000/docker:tag3"
-	if repoTags[0] != expected {
-		t.Fatal("got unexpected repo tag (%s != %s)", repoTags[0], "utest:5000/docker:tag3")
-	}
+	images := getImages(eng, t, false, "utest*/*")
 
-	images = getImages(eng, t, false, registry.INDEXNAME+"/utest*/*")
-	repoTags = images[0].RepoTags
-	if len(repoTags) != 1 {
-		t.Fatal("incorrect number of matches returned")
-	}
-	expected = registry.INDEXNAME + "/utest/docker:tag2"
-	if repoTags[0] != expected {
-		t.Fatal("got unexpected repo tag (%s != %s)", repoTags[0], expected)
-	}
-
-	images = getImages(eng, t, false, registry.INDEXNAME+"/*test*")
-	if len(images[0].RepoTags) != 2 {
+	if len(images.Data[0].GetList("RepoTags")) != 2 {
 		t.Fatal("incorrect number of matches returned")
 	}
 
-	images = getImages(eng, t, false, registry.INDEXNAME+"/utest")
-	if len(images[0].RepoTags) != 1 {
+	images = getImages(eng, t, false, "utest")
+
+	if len(images.Data[0].GetList("RepoTags")) != 1 {
 		t.Fatal("incorrect number of matches returned")
 	}
 
-	images = getImages(eng, t, false, registry.INDEXNAME+"/utest*")
-	if len(images[0].RepoTags) != 1 {
+	images = getImages(eng, t, false, "utest*")
+
+	if len(images.Data[0].GetList("RepoTags")) != 1 {
 		t.Fatal("incorrect number of matches returned")
 	}
 
 	images = getImages(eng, t, false, "*5000*/*")
-	if len(images[0].RepoTags) != 1 {
+
+	if len(images.Data[0].GetList("RepoTags")) != 1 {
 		t.Fatal("incorrect number of matches returned")
 	}
 }


### PR DESCRIPTION
Do not fully-qualify tags given on command line:

    $ docker tag repo/name dest/name

Prior to this patch `dest/name` would be prefixed with default registry.
Now only pulled images will be fully-qualified.