### PR TITLE
Allow for unprotected push to public registry

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -858,9 +858,9 @@ func (s *Server) postImagesPush(eng *engine.Engine, version version.Version, w h
 		MetaHeaders: metaHeaders,
 		AuthConfig:  authConfig,
 		Tag:         r.Form.Get("tag"),
+		Force:       boolValue(r, "force"),
 		OutStream:   output,
 		Json:        useJSON,
-		Force:       boolValue(r, "force"),
 	}
 	if useJSON {
 		w.Header().Set("Content-Type", "application/json")

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -48,6 +48,7 @@ complete -c docker -f -n '__fish_docker_no_subcommand' -l api-cors-header -d "Se
 complete -c docker -f -n '__fish_docker_no_subcommand' -s b -l bridge -d 'Attach containers to a pre-existing network bridge'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l bip -d "Use this CIDR notation address for the network bridge's IP, not compatible with -b"
 complete -c docker -f -n '__fish_docker_no_subcommand' -l block-registry -d "Don't contact given registry"
+complete -c docker -f -n '__fish_docker_no_subcommand' -l confirm-def-push -d 'Confirm a push to default registry'
 complete -c docker -f -n '__fish_docker_no_subcommand' -s D -l debug -d 'Enable debug mode'
 complete -c docker -f -n '__fish_docker_no_subcommand' -s d -l daemon -d 'Enable daemon mode'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l dns -d 'Force Docker to use specific DNS servers'
@@ -70,6 +71,7 @@ complete -c docker -f -n '__fish_docker_no_subcommand' -s l -l log-level -d 'Set
 complete -c docker -f -n '__fish_docker_no_subcommand' -l label -d 'Set key=value labels to the daemon (displayed in `docker info`)'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l mtu -d 'Set the containers network MTU'
 complete -c docker -f -n '__fish_docker_no_subcommand' -s p -l pidfile -d 'Path to use for daemon PID file'
+complete -c docker -f -n '__fish_docker_no_subcommand' -l protect-push -d 'Protect against a push to public registry'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l registry-mirror -d 'Specify a preferred Docker registry mirror'
 complete -c docker -f -n '__fish_docker_no_subcommand' -s s -l storage-driver -d 'Force the Docker runtime to use a specific storage driver'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l selinux-enabled -d 'Enable selinux support. SELinux does not presently support the BTRFS storage driver'

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	LogConfig            runconfig.LogConfig
 	BlockedRegistries    opts.ListOpts
 	AdditionalRegistries opts.ListOpts
+	ConfirmDefPush       bool
 }
 
 // InstallFlags adds command-line options to the top-level flag parser for
@@ -84,6 +85,7 @@ func (config *Config) InstallFlags() {
 	flag.Var(&config.BlockedRegistries, []string{"-block-registry"}, "Don't contact given registry")
 	config.AdditionalRegistries = opts.NewListOpts(registry.ValidateIndexName)
 	flag.Var(&config.AdditionalRegistries, []string{"-add-registry"}, "Registry to query before a public one")
+	flag.BoolVar(&config.ConfirmDefPush, []string{"-confirm-def-push"}, true, "Confirm a push to default registry")
 }
 
 func getDefaultNetworkMtu() int {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -891,11 +891,12 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine, registryService 
 	eventsService := events.New()
 	logrus.Debug("Creating repository list")
 	tagCfg := &graph.TagStoreConfig{
-		Graph:    g,
-		Key:      trustKey,
-		Registry: registryService,
-		Events:   eventsService,
-		Trust:    trustService,
+		Graph:          g,
+		Key:            trustKey,
+		Registry:       registryService,
+		Events:         eventsService,
+		Trust:          trustService,
+		ConfirmDefPush: config.ConfirmDefPush,
 	}
 	repositories, err := graph.NewTagStore(path.Join(config.Root, "repositories-"+driver.String()), tagCfg)
 	if err != nil {

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -41,6 +41,9 @@ To see the man page for a command run **man docker <command>**.
 **--block-registry**=[]
   **EXPERIMENTAL** Prevent Docker daemon from contacting specified registries. There are two special keywords recognized. The first is "public" and represents public Docker registry. The second is "all" which causes all registries but those added with **--add-registry** flag to be blocked.
 
+**--confirm-def-push**=*true*|*false*
+  Makes Docker ask for a confirmation before a push to public registry. Default is true.
+
 **-D**, **--debug**=*true*|*false*
   Enable debug mode. Default is false.
 
@@ -110,6 +113,9 @@ unix://[/path/to/socket] to use.
 
 **-p**, **--pidfile**=""
   Path to use for daemon PID file. Default is `/var/run/docker.pid`
+
+**--protect-push**=*true*|*false*
+  Makes Docker ask for a confirmation to push to public registry. Default is true.
 
 **--registry-mirror**=<scheme>://<host>
   Prepend a registry mirror to be used for image pulls from public Docker registry. May be specified multiple times.

--- a/graph/push.go
+++ b/graph/push.go
@@ -505,9 +505,9 @@ func (s *TagStore) Push(localName string, imagePushConfig *ImagePushConfig) erro
 		return err
 	}
 
-	if repoInfo.Index.Official && !imagePushConfig.Force {
+	if repoInfo.Index.Official && s.ConfirmDefPush && !imagePushConfig.Force {
 		return fmt.Errorf("Error: Status 403 trying to push repository %s to official registry: needs to be forced", localName)
-	} else if repoInfo.Index.Official && imagePushConfig.Force {
+	} else if repoInfo.Index.Official && !s.ConfirmDefPush && imagePushConfig.Force {
 		logrus.Infof("Push of %s to official registry has been forced", localName)
 	}
 

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -44,6 +44,7 @@ type TagStore struct {
 	registryService *registry.Service
 	eventsService   *events.Events
 	trustService    *trust.TrustStore
+	ConfirmDefPush  bool
 }
 
 type Repository map[string]string
@@ -67,11 +68,12 @@ func (r Repository) Contains(u Repository) bool {
 }
 
 type TagStoreConfig struct {
-	Graph    *Graph
-	Key      libtrust.PrivateKey
-	Registry *registry.Service
-	Events   *events.Events
-	Trust    *trust.TrustStore
+	Graph          *Graph
+	Key            libtrust.PrivateKey
+	Registry       *registry.Service
+	Events         *events.Events
+	Trust          *trust.TrustStore
+	ConfirmDefPush bool
 }
 
 func NewTagStore(path string, cfg *TagStoreConfig) (*TagStore, error) {
@@ -90,6 +92,7 @@ func NewTagStore(path string, cfg *TagStoreConfig) (*TagStore, error) {
 		registryService: cfg.Registry,
 		eventsService:   cfg.Events,
 		trustService:    cfg.Trust,
+		ConfirmDefPush:  cfg.ConfirmDefPush,
 	}
 	// Load the json file if it exists, otherwise create it.
 	if err := store.reload(); os.IsNotExist(err) {


### PR DESCRIPTION
Allow for push to public registry without confirmation
Added `--confirm-def-push` boolean flag to Docker daemon. It causes
client to ask for confirmation before a push to public registry. It
defaults to `true`. If set to `false`, push won't be restricted in any
way unless the registry in question is blocked.