### PR TITLE
Allow for push to public registry without confirmation

### DIFF
--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -48,6 +48,7 @@ complete -c docker -f -n '__fish_docker_no_subcommand' -l api-cors-header -d "Se
 complete -c docker -f -n '__fish_docker_no_subcommand' -s b -l bridge -d 'Attach containers to a pre-existing network bridge'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l bip -d "Use this CIDR notation address for the network bridge's IP, not compatible with -b"
 complete -c docker -f -n '__fish_docker_no_subcommand' -l block-registry -d "Don't contact given registry"
+complete -c docker -f -n '__fish_docker_no_subcommand' -l confirm-def-push -d 'Confirm a push to default registry'
 complete -c docker -f -n '__fish_docker_no_subcommand' -s D -l debug -d 'Enable debug mode'
 complete -c docker -f -n '__fish_docker_no_subcommand' -s d -l daemon -d 'Enable daemon mode'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l dns -d 'Force Docker to use specific DNS servers'

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	LogConfig                   runconfig.LogConfig
 	BlockedRegistries           opts.ListOpts
 	AdditionalRegistries        opts.ListOpts
+	ConfirmDefPush              bool
 }
 
 // InstallFlags adds command-line options to the top-level flag parser for
@@ -91,6 +92,7 @@ func (config *Config) InstallFlags() {
 	flag.Var(&config.BlockedRegistries, []string{"-block-registry"}, "Don't contact given registry")
 	config.AdditionalRegistries = opts.NewListOpts(registry.ValidateIndexName)
 	flag.Var(&config.AdditionalRegistries, []string{"-add-registry"}, "Registry to query before a public one")
+	flag.BoolVar(&config.ConfirmDefPush, []string{"-confirm-def-push"}, true, "Confirm a push to default registry")
 }
 
 func getDefaultNetworkMtu() int {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -928,7 +928,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 	}
 
 	log.Debugf("Creating repository list")
-	repositories, err := graph.NewTagStore(path.Join(config.Root, "repositories-"+driver.String()), g, trustKey)
+	repositories, err := graph.NewTagStore(path.Join(config.Root, "repositories-"+driver.String()), g, trustKey, config.ConfirmDefPush)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't create Tag store: %s", err)
 	}

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -41,6 +41,9 @@ To see the man page for a command run **man docker <command>**.
 **--block-registry**=[]
   **EXPERIMENTAL** Prevent Docker daemon from contacting specified registries. There are two special keywords recognized. The first is "public" and represents public Docker registry. The second is "all" which causes all registries but those added with **--add-registry** flag to be blocked.
 
+**--confirm-def-push**=*true*|*false*
+  Makes Docker ask for a confirmation before a push to public registry. Default is true.
+
 **-D**, **--debug**=*true*|*false*
   Enable debug mode. Default is false.
 

--- a/graph/push.go
+++ b/graph/push.go
@@ -507,9 +507,9 @@ func (s *TagStore) CmdPush(job *engine.Job) engine.Status {
 	job.GetenvJson("metaHeaders", &metaHeaders)
 	force := job.GetenvBool("force")
 
-	if repoInfo.Index.Official && !force {
+	if repoInfo.Index.Official && s.ConfirmDefPush && !force {
 		return job.Errorf("Error: Status 403 trying to push repository %s to official registry: needs to be forced", localName)
-	} else if repoInfo.Index.Official && force {
+	} else if repoInfo.Index.Official && !s.ConfirmDefPush && force {
 		log.Infof("Push of %s to official registry has been forced", localName)
 	}
 

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -36,8 +36,9 @@ type TagStore struct {
 	sync.Mutex
 	// FIXME: move push/pull-related fields
 	// to a helper type
-	pullingPool map[string]chan struct{}
-	pushingPool map[string]chan struct{}
+	pullingPool    map[string]chan struct{}
+	pushingPool    map[string]chan struct{}
+	ConfirmDefPush bool
 }
 
 type Repository map[string]string
@@ -60,19 +61,20 @@ func (r Repository) Contains(u Repository) bool {
 	return true
 }
 
-func NewTagStore(path string, graph *Graph, key libtrust.PrivateKey) (*TagStore, error) {
+func NewTagStore(path string, graph *Graph, key libtrust.PrivateKey, confirmDefPush bool) (*TagStore, error) {
 	abspath, err := filepath.Abs(path)
 	if err != nil {
 		return nil, err
 	}
 
 	store := &TagStore{
-		path:         abspath,
-		graph:        graph,
-		trustKey:     key,
-		Repositories: make(map[string]Repository),
-		pullingPool:  make(map[string]chan struct{}),
-		pushingPool:  make(map[string]chan struct{}),
+		path:           abspath,
+		graph:          graph,
+		trustKey:       key,
+		Repositories:   make(map[string]Repository),
+		pullingPool:    make(map[string]chan struct{}),
+		pushingPool:    make(map[string]chan struct{}),
+		ConfirmDefPush: confirmDefPush,
 	}
 	// Load the json file if it exists, otherwise create it.
 	if err := store.reload(); os.IsNotExist(err) {

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -63,7 +63,7 @@ func mkTestTagStore(root string, t *testing.T) *TagStore {
 	if err != nil {
 		t.Fatal(err)
 	}
-	store, err := NewTagStore(path.Join(root, "tags"), graph, nil)
+	store, err := NewTagStore(path.Join(root, "tags"), graph, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Added `--confirm-def-push` boolean flag to Docker daemon. It causes
client to ask for confirmation before a push to public registry. It
defaults to `true`. If set to `false`, push won't be restricted in any
way unless the registry in question is blocked.

Signed-off-by: Michal Minar <miminar@redhat.com>