### PR TITLE
'docker rmi -f IMAGE_ID' untag all names and delete the image

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1703,6 +1703,21 @@ before the image is removed.
     Untagged: test:latest
     Deleted: fd484f19954f4920da7ff372b5067f5b7ddb2fd3830cecd17b96ea9e286ba5b8
 
+If you use the `-f` flag and specify the image's short or long ID, then this
+command untags and removes all images that match the specified ID.
+
+    $ docker images
+    REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
+    test1                     latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
+    test                      latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
+    test2                     latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
+
+    $ docker rmi -f fd484f19954f
+    Untagged: test1:latest
+    Untagged: test:latest
+    Untagged: test2:latest
+    Deleted: fd484f19954f4920da7ff372b5067f5b7ddb2fd3830cecd17b96ea9e286ba5b8
+
 An image pulled by digest has no tag associated with it:
 
     $ sudo docker images --digests

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -95,6 +95,43 @@ func TestRmiTag(t *testing.T) {
 	logDone("rmi - tag,rmi- tagging the same images multiple times then removing tags")
 }
 
+func TestRmiImgIDForce(t *testing.T) {
+	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir '/busybox-test'")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatalf("failed to create a container:%s, %v", out, err)
+	}
+	containerID := strings.TrimSpace(out)
+	runCmd = exec.Command(dockerBinary, "commit", containerID, "busybox-test")
+	out, _, err = runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatalf("failed to commit a new busybox-test:%s, %v", out, err)
+	}
+
+	imagesBefore, _, _ := dockerCmd(t, "images", "-a")
+	dockerCmd(t, "tag", "busybox-test", "utest:tag1")
+	dockerCmd(t, "tag", "busybox-test", "utest:tag2")
+	dockerCmd(t, "tag", "busybox-test", "utest/docker:tag3")
+	dockerCmd(t, "tag", "busybox-test", "utest:5000/docker:tag4")
+	{
+		imagesAfter, _, _ := dockerCmd(t, "images", "-a")
+		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+4 {
+			t.Fatalf("tag busybox to create 4 more images with same imageID; docker images shows: %q\n", imagesAfter)
+		}
+	}
+	out, _, _ = dockerCmd(t, "inspect", "-f", "{{.Id}}", "busybox-test")
+	imgID := strings.TrimSpace(out)
+	dockerCmd(t, "rmi", "-f", imgID)
+	{
+		imagesAfter, _, _ := dockerCmd(t, "images", "-a")
+		if strings.Contains(imagesAfter, imgID[:12]) {
+			t.Fatalf("rmi -f %s failed, image still exists: %q\n\n", imgID, imagesAfter)
+		}
+
+	}
+	logDone("rmi - imgID,rmi -f imgID  delete all tagged repos of specific imgID")
+}
+
 func TestRmiTagWithExistingContainers(t *testing.T) {
 	defer deleteAllContainers()
 


### PR DESCRIPTION
If an image has been tagged to multiple repos and tags, 'docker
rmi -f IMAGE_ID' will just untag one random repo instead of
untagging all and deleting the image. This patch implement
this. This commit is composed of:

        *untag all names and delete the image

        *add test to this feature

        *modify commandline/cli.md to explain this

Resolves: rhbz#1222784