### PR TITLE
Exposed registry list via docker info API.

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -30,6 +30,13 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 
 	fmt.Fprintf(cli.out, "Containers: %d\n", info.Containers)
 	fmt.Fprintf(cli.out, "Images: %d\n", info.Images)
+
+	fmt.Fprintf(cli.out, "Registries: %d\n", len(info.RegistryList))
+
+	for _, registry := range info.RegistryList {
+		fmt.Fprintf(cli.out, " %s\n", registry)
+	}
+
 	ioutils.FprintfIfNotEmpty(cli.out, "Storage Driver: %s\n", info.Driver)
 	if info.DriverStatus != nil {
 		for _, pair := range info.DriverStatus {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -165,6 +165,7 @@ type Info struct {
 	OperatingSystem    string
 	IndexServerAddress string
 	RegistryConfig     interface{}
+	RegistryList       []string
 	InitSha1           string
 	InitPath           string
 	NCPU               int

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -79,6 +79,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		OperatingSystem:    operatingSystem,
 		IndexServerAddress: registry.IndexServerAddress(),
 		RegistryConfig:     daemon.RegistryService.Config,
+		RegistryList:       registry.RegistryList,
 		InitSha1:           dockerversion.INITSHA1,
 		InitPath:           initPath,
 		NCPU:               runtime.NumCPU(),

--- a/docs/man/docker-info.1.md
+++ b/docs/man/docker-info.1.md
@@ -11,9 +11,10 @@ docker-info - Display system-wide information
 
 # DESCRIPTION
 This command displays system wide information regarding the Docker installation.
-Information displayed includes the number of containers and images, pool name,
-data file, metadata file, data space used, total data space, metadata space used
-, total metadata space, execution driver, and the kernel version.
+Information displayed includes the number of containers and images, list of
+configured registires, pool name, data file, metadata file, data space used,
+total data space, metadata space used, total metadata space, execution driver,
+and the kernel version.
 
 The data file is where the images are stored and the metadata file is where the
 meta data regarding those images are stored. When run for the first time Docker
@@ -33,6 +34,8 @@ Here is a sample output:
     # docker info
     Containers: 14
     Images: 52
+    Registries: 1
+     docker.io
     Storage Driver: aufs
      Root Dir: /var/lib/docker/aufs
      Dirs: 80
@@ -47,3 +50,4 @@ Here is a sample output:
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+June 2015, updated by William Temple <wtemple at redhat dot com>


### PR DESCRIPTION
Adds a 'RegistryList' key to the docker info API and CLI output reflecting the configuration of the registry package.

Signed-off-by: William Temple <wtemple@redhat.com>