### PR TITLE
Remove existing Seccomp impl to fix build failure on non-AMD64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ DOCKER_RUN_DOCKER := docker run --rm -it --privileged $(DOCKER_ENVS) $(DOCKER_MO
 
 DOCKER_RUN_DOCS := docker run --rm -it $(DOCS_MOUNT) -e AWS_S3_BUCKET -e NOCACHE
 
+DOCKER_FILE := $(shell go run ./patches/gen_dockerfile.go)
+
 # for some docs workarounds (see below in "docs-build" target)
 GITCOMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
 
@@ -71,7 +73,7 @@ shell: build
 	$(DOCKER_RUN_DOCKER) bash
 
 build: bundles
-	docker build -t "$(DOCKER_IMAGE)" .
+	docker build -t "$(DOCKER_IMAGE)" -f $(DOCKER_FILE) .
 
 bundles:
 	mkdir bundles

--- a/api/client/stop.go
+++ b/api/client/stop.go
@@ -12,6 +12,7 @@ import (
 // CmdStop stops one or more running containers.
 //
 // A running container is stopped by first sending SIGTERM and then SIGKILL if the container fails to stop within a grace period (the default is 10 seconds).
+// If the container is running in Init="systemd" mode, docker will send the SIGRTMIN+3 signal
 //
 // Usage: docker stop [OPTIONS] CONTAINER [CONTAINER...]
 func (cli *DockerCli) CmdStop(args ...string) error {

--- a/api/client/version.go
+++ b/api/client/version.go
@@ -10,11 +10,13 @@ import (
 	"github.com/docker/docker/autogen/dockerversion"
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/pkg/rpm"
 	"github.com/docker/docker/utils"
 )
 
 var VersionTemplate = `Client:
  Version:      {{.Client.Version}}
+ Package Version: {{.Client.PackageVersion}}
  API version:  {{.Client.ApiVersion}}
  Go version:   {{.Client.GoVersion}}
  Git commit:   {{.Client.GitCommit}}
@@ -24,6 +26,7 @@ var VersionTemplate = `Client:
 
 Server:
  Version:      {{.Server.Version}}
+ Package Version: {{.Server.PackageVersion}}
  API version:  {{.Server.ApiVersion}}
  Go version:   {{.Server.GoVersion}}
  Git commit:   {{.Server.GitCommit}}
@@ -58,16 +61,18 @@ func (cli *DockerCli) CmdVersion(args ...string) (err error) {
 			Status: "Template parsing error: " + err.Error()}
 	}
 
+	packageVersion, _ := rpm.Version("/usr/bin/docker")
 	vd := VersionData{
 		Client: types.Version{
-			Version:      dockerversion.VERSION,
-			ApiVersion:   api.Version,
-			GoVersion:    runtime.Version(),
-			GitCommit:    dockerversion.GITCOMMIT,
-			BuildTime:    dockerversion.BUILDTIME,
-			Os:           runtime.GOOS,
-			Arch:         runtime.GOARCH,
-			Experimental: utils.ExperimentalBuild(),
+			Version:        dockerversion.VERSION,
+			ApiVersion:     api.Version,
+			GoVersion:      runtime.Version(),
+			GitCommit:      dockerversion.GITCOMMIT,
+			BuildTime:      dockerversion.BUILDTIME,
+			Os:             runtime.GOOS,
+			Arch:           runtime.GOARCH,
+			Experimental:   utils.ExperimentalBuild(),
+			PackageVersion: packageVersion,
 		},
 	}
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/parsers/filters"
 	"github.com/docker/docker/pkg/parsers/kernel"
+	"github.com/docker/docker/pkg/rpm"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/pkg/sockets"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -261,6 +262,9 @@ func (s *Server) getVersion(version version.Version, w http.ResponseWriter, r *h
 		v.KernelVersion = kernelVersion.String()
 	}
 
+	if out, err := rpm.Version("/usr/bin/docker"); err == nil {
+		v.PackageVersion = out
+	}
 	return writeJSON(w, http.StatusOK, v)
 }
 

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -147,15 +147,16 @@ type ContainerProcessList struct {
 }
 
 type Version struct {
-	Version       string
-	ApiVersion    version.Version
-	GitCommit     string
-	GoVersion     string
-	Os            string
-	Arch          string
-	KernelVersion string `json:",omitempty"`
-	Experimental  bool   `json:",omitempty"`
-	BuildTime     string `json:",omitempty"`
+	Version        string
+	ApiVersion     version.Version
+	GitCommit      string
+	GoVersion      string
+	Os             string
+	Arch           string
+	KernelVersion  string `json:",omitempty"`
+	Experimental   bool   `json:",omitempty"`
+	BuildTime      string `json:",omitempty"`
+	PackageVersion string `json:",omitempty"`
 }
 
 // GET "/info"

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -951,6 +951,7 @@ _docker_run() {
 		--expose
 		--group-add
 		--hostname -h
+		--init
 		--ipc
 		--label -l
 		--label-file
@@ -1032,6 +1033,10 @@ _docker_run() {
 		--env|-e)
 			COMPREPLY=( $( compgen -e -- "$cur" ) )
 			compopt -o nospace
+			return
+			;;
+		--init)
+			COMPREPLY=( $( compgen -W 'systemd' -- "$cur" ) )
 			return
 			;;
 		--ipc)

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -131,6 +131,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l group-add -d
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -s h -l hostname -d 'Container host name'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l help -d 'Print usage'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -s i -l interactive -d 'Keep STDIN open even if not attached'
+complete -c docker -A -f -n '__fish_seen_subcommand_from create' -s a -l init -d 'Init to systemd.'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l ipc -d 'Default is to create a private IPC namespace (POSIX SysV IPC) for the container'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l link -d 'Add link to another container in the form of <name|id>:alias'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l lxc-conf -d '(lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"'
@@ -300,6 +301,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from rmi' -a '(__fish_print_
 # run
 complete -c docker -f -n '__fish_docker_no_subcommand' -a run -d 'Run a command in a new container'
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -s a -l attach -d 'Attach to STDIN, STDOUT or STDERR.'
+complete -c docker -A -f -n '__fish_seen_subcommand_from run' -s a -l init -d 'Init to systemd.'
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -l add-host -d 'Add a custom host-to-IP mapping (host:ip)'
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -s c -l cpu-shares -d 'CPU shares (relative weight)'
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -l cap-add -d 'Add Linux capabilities'

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -281,6 +281,24 @@ func (container *Container) Start() (err error) {
 		return err
 	}
 
+	defer func() {
+		// Now the container is running, unmount the secrets on the host
+		secretsPath, err := container.secretsPath()
+		if err != nil {
+			logrus.Errorf("%v: Secrets Path does not exist: %v", container.ID, err)
+			return
+		}
+
+		if err := syscall.Unmount(secretsPath, syscall.MNT_DETACH); err != nil {
+			logrus.Errorf("%v: Failed to umount %s filesystem: %v", container.ID, secretsPath, err)
+			return
+		}
+	}()
+
+	if err := container.setupSecretFiles(); err != nil {
+		return err
+	}
+
 	mounts, err := container.setupMounts()
 	if err != nil {
 		return err

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1104,8 +1104,12 @@ func copyEscapable(dst io.Writer, src io.ReadCloser) (written int64, err error) 
 
 func (container *Container) networkMounts() []execdriver.Mount {
 	var mounts []execdriver.Mount
+	mode := "Z"
+	if container.hostConfig.NetworkMode.IsContainer() {
+		mode = "z"
+	}
 	if container.ResolvConfPath != "" {
-		label.SetFileLabel(container.ResolvConfPath, container.MountLabel)
+		label.Relabel(container.ResolvConfPath, container.MountLabel, mode)
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.ResolvConfPath,
 			Destination: "/etc/resolv.conf",
@@ -1114,7 +1118,7 @@ func (container *Container) networkMounts() []execdriver.Mount {
 		})
 	}
 	if container.HostnamePath != "" {
-		label.SetFileLabel(container.HostnamePath, container.MountLabel)
+		label.Relabel(container.HostnamePath, container.MountLabel, mode)
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.HostnamePath,
 			Destination: "/etc/hostname",
@@ -1123,7 +1127,7 @@ func (container *Container) networkMounts() []execdriver.Mount {
 		})
 	}
 	if container.HostsPath != "" {
-		label.SetFileLabel(container.HostsPath, container.MountLabel)
+		label.Relabel(container.HostsPath, container.MountLabel, mode)
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.HostsPath,
 			Destination: "/etc/hosts",

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -505,8 +505,14 @@ func (container *Container) Stop(seconds int) error {
 	}
 
 	// 1. Send a SIGTERM
-	if err := container.killPossiblyDeadProcess(15); err != nil {
-		logrus.Infof("Failed to send SIGTERM to the process, force killing")
+	sig := 15
+	sigString := "SIGTERM"
+	if container.Config.Init == "systemd" {
+		sig = 35 //signal.
+		sigString = "SIGRTMIN + 3"
+	}
+	if err := container.killPossiblyDeadProcess(sig); err != nil {
+		logrus.Infof(fmt.Sprintf("Failed to send %s to the process, force killing", sigString))
 		if err := container.killPossiblyDeadProcess(9); err != nil {
 			return err
 		}

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -138,6 +138,7 @@ func (container *Container) createDaemonEnvironment(linkedEnv []string) []string
 	// because the env on the container can override certain default values
 	// we need to replace the 'env' keys where they match and append anything
 	// else.
+	env = append(env, fmt.Sprintf("container_uuid=%s", convertUUID(container.ID)))
 	env = utils.ReplaceOrAppendEnvValues(env, container.Config.Env)
 
 	return env

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -33,6 +33,7 @@ import (
 	"github.com/docker/libnetwork/types"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
+	"github.com/opencontainers/runc/libcontainer/label"
 )
 
 const DefaultPathEnv = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -1149,5 +1150,33 @@ func (container *Container) PrepareStorage() error {
 }
 
 func (container *Container) CleanupStorage() error {
+	return nil
+}
+
+func (container *Container) secretsPath() (string, error) {
+	return container.GetRootResourcePath("secrets")
+}
+func (container *Container) setupSecretFiles() error {
+	secretsPath, err := container.secretsPath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(secretsPath, 0700); err != nil {
+		return err
+	}
+
+	if err := syscall.Mount("tmpfs", secretsPath, "tmpfs", uintptr(syscall.MS_NOEXEC|syscall.MS_NOSUID|syscall.MS_NODEV), label.FormatMountLabel("", container.GetMountLabel())); err != nil {
+		return fmt.Errorf("mounting secret tmpfs: %s", err)
+	}
+
+	data, err := getHostSecretData()
+	if err != nil {
+		return err
+	}
+	for _, s := range data {
+		s.SaveTo(secretsPath)
+	}
+
 	return nil
 }

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -123,6 +123,12 @@ func (daemon *Daemon) rm(container *Container, forceRemove bool) (err error) {
 		}
 	}
 
+	if path := journalPath(container.ID); path != "" {
+		if err = os.RemoveAll(path); err != nil {
+			return fmt.Errorf("Unable to remove journal content %v: %v", container.ID, err)
+		}
+	}
+
 	if err = os.RemoveAll(container.root); err != nil {
 		return fmt.Errorf("Unable to remove filesystem for %v: %v", container.ID, err)
 	}

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -177,4 +177,5 @@ type Command struct {
 	FirstStart         bool              `json:"first_start"`
 	LayerPaths         []string          `json:"layer_paths"` // Windows needs to know the layer paths and folder for a command
 	LayerFolder        string            `json:"layer_folder"`
+	TmpDir             string            `json:"tmpdir"` // Directory used to store docker tmpdirs.
 }

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -223,6 +225,34 @@ func (d *driver) setupRlimits(container *configs.Config, c *execdriver.Command) 
 	}
 }
 
+func (d *driver) genPremountCmd(c *execdriver.Command, fullDest string, dest string) []configs.Command {
+	var premount []configs.Command
+	tarFile := fmt.Sprintf("%s/%s.tar", c.TmpDir, strings.Replace(dest, "/", "_", -1))
+	if _, err := os.Stat(fullDest); err == nil {
+		premount = append(premount, configs.Command{
+			Path: "/usr/bin/tar",
+			Args: []string{"-cf", tarFile, "-C", fullDest, "."},
+		})
+	}
+	return premount
+}
+
+func (d *driver) genPostmountCmd(c *execdriver.Command, fullDest string, dest string) []configs.Command {
+	var postmount []configs.Command
+	if _, err := os.Stat(fullDest); os.IsNotExist(err) {
+		return postmount
+	}
+	tarFile := fmt.Sprintf("%s/%s.tar", c.TmpDir, strings.Replace(dest, "/", "_", -1))
+	postmount = append(postmount, configs.Command{
+		Path: "/usr/bin/tar",
+		Args: []string{"-xf", tarFile, "-C", fullDest, "."},
+	})
+	return append(postmount, configs.Command{
+		Path: "/usr/bin/rm",
+		Args: []string{"-f", tarFile},
+	})
+}
+
 func (d *driver) setupMounts(container *configs.Config, c *execdriver.Command) error {
 	userMounts := make(map[string]struct{})
 	for _, m := range c.Mounts {
@@ -243,6 +273,20 @@ func (d *driver) setupMounts(container *configs.Config, c *execdriver.Command) e
 	container.Mounts = defaultMounts
 
 	for _, m := range c.Mounts {
+		if m.Source == "tmpfs" {
+			dest := filepath.Join(c.Rootfs, m.Destination)
+			flags := syscall.MS_NOSUID | syscall.MS_NODEV
+			container.Mounts = append(container.Mounts, &configs.Mount{
+				Source:        m.Source,
+				Destination:   m.Destination,
+				Device:        "tmpfs",
+				Data:          "mode=755,size=65536k",
+				Flags:         flags,
+				PremountCmds:  d.genPremountCmd(c, dest, m.Destination),
+				PostmountCmds: d.genPostmountCmd(c, dest, m.Destination),
+			})
+			continue
+		}
 		flags := syscall.MS_BIND | syscall.MS_REC
 		if !m.Writable {
 			flags |= syscall.MS_RDONLY

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -5,6 +5,7 @@ package native
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -112,6 +113,13 @@ type execOutput struct {
 
 func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (execdriver.ExitStatus, error) {
 	// take the Command and populate the libcontainer.Config from it
+	var err error
+	c.TmpDir, err = ioutil.TempDir("", c.ID)
+	if err != nil {
+		return execdriver.ExitStatus{ExitCode: -1}, err
+	}
+	defer os.RemoveAll(c.TmpDir)
+
 	container, err := d.createContainer(c)
 	if err != nil {
 		return execdriver.ExitStatus{ExitCode: -1}, err

--- a/daemon/graphdriver/devmapper/README.md
+++ b/daemon/graphdriver/devmapper/README.md
@@ -3,12 +3,21 @@
 ### Theory of operation
 
 The device mapper graphdriver uses the device mapper thin provisioning
-module (dm-thinp) to implement CoW snapshots. For each devicemapper
-graph location (typically `/var/lib/docker/devicemapper`, $graph below)
-a thin pool is created based on two block devices, one for data and
-one for metadata.  By default these block devices are created
-automatically by using loopback mounts of automatically created sparse
-files.
+module (dm-thinp) to implement CoW snapshots.  The preferred model is
+to have a thin pool reserved outside of Docker, and passed to the
+daemon via the `--storage-opt dm.thinpooldev` option.
+
+As a fallback if no thin pool is provided, loopback files will be
+created.  Loopback is very slow, but can be used without any
+pre-configuration of storage.  It is *strongly recommended* to not use
+loopback in production.  Ensure your docker daemon has a
+`--storage-opt dm.thinpooldev` argument provided.
+
+In loopback, each devicemapper graph location (typically
+`/var/lib/docker/devicemapper`, $graph below) a thin pool is created
+based on two block devices, one for data and one for metadata.  By
+default these block devices are created automatically by using
+loopback mounts of automatically created sparse files.
 
 The default loopback files used are `$graph/devicemapper/data` and
 `$graph/devicemapper/metadata`. Additional metadata required to map
@@ -82,3 +91,203 @@ page](../../../man/docker.1.md) and in [the online
 documentation](https://docs.docker.com/reference/commandline/daemon/#docker-
 execdriver-option).  If you add an options, update both the `man` page and the
 documentation.
+
+Here is the list of supported options:
+
+ *  `dm.basesize`
+
+    Specifies the size to use when creating the base device, which
+    limits the size of images and containers. The default value is
+    10G. Note, thin devices are inherently "sparse", so a 10G device
+    which is mostly empty doesn't use 10 GB of space on the
+    pool. However, the filesystem will use more space for the empty
+    case the larger the device is. **Warning**: This value affects the
+    system-wide "base" empty filesystem that may already be
+    initialized and inherited by pulled images.  Typically, a change
+    to this value will require additional steps to take effect: 1)
+    stop `docker -d`, 2) `rm -rf /var/lib/docker`, 3) start `docker -d`.
+
+    Example use:
+
+    ``docker -d --storage-opt dm.basesize=20G``
+
+ *  `dm.loopdatasize`
+
+    Specifies the size to use when creating the loopback file for the
+    "data" device which is used for the thin pool. The default size is
+    100G. Note that the file is sparse, so it will not initially take
+    up this much space.
+
+    Example use:
+
+    ``docker -d --storage-opt dm.loopdatasize=200G``
+
+ *  `dm.loopmetadatasize`
+
+    Specifies the size to use when creating the loopback file for the
+    "metadadata" device which is used for the thin pool. The default size is
+    2G. Note that the file is sparse, so it will not initially take
+    up this much space.
+
+    Example use:
+
+    ``docker -d --storage-opt dm.loopmetadatasize=4G``
+
+ *  `dm.fs`
+
+    Specifies the filesystem type to use for the base device. The supported
+    options are "ext4" and "xfs". The default is "ext4"
+
+    Example use:
+
+    ``docker -d --storage-opt dm.fs=xfs``
+
+ *  `dm.mkfsarg`
+
+    Specifies extra mkfs arguments to be used when creating the base device.
+
+    Example use:
+
+    ``docker -d --storage-opt "dm.mkfsarg=-O ^has_journal"``
+
+ *  `dm.mountopt`
+
+    Specifies extra mount options used when mounting the thin devices.
+
+    Example use:
+
+    ``docker -d --storage-opt dm.mountopt=nodiscard``
+
+ *  `dm.thinpooldev`
+
+    Specifies a custom blockdevice to use for the thin pool.
+
+    If using a block device for device mapper storage, ideally lvm2
+    would be used to create/manage the thin-pool volume that is then
+    handed to docker to exclusively create/manage the thin and thin
+    snapshot volumes needed for its containers.  Managing the thin-pool
+    outside of docker makes for the most feature-rich method of having
+    docker utilize device mapper thin provisioning as the backing
+    storage for docker's containers.  lvm2-based thin-pool management
+    feature highlights include: automatic or interactive thin-pool
+    resize support, dynamically change thin-pool features, automatic
+    thinp metadata checking when lvm2 activates the thin-pool, etc.
+
+    Example use:
+
+    ``docker -d --storage-opt dm.thinpooldev=/dev/mapper/thin-pool``
+
+ *  `dm.datadev`
+
+    (Deprecated, use dm.thinpooldev)
+
+    Specifies a custom blockdevice to use for data for the thin pool.
+
+    If using a block device for device mapper storage, ideally both
+    datadev and metadatadev should be specified to completely avoid
+    using the loopback device.
+
+    Example use:
+
+    ``docker -d --storage-opt dm.datadev=/dev/sdb1 --storage-opt dm.metadatadev=/dev/sdc1``
+
+ *  `dm.metadatadev`
+
+    (Deprecated, use dm.thinpooldev)
+
+    Specifies a custom blockdevice to use for metadata for the thin
+    pool.
+
+    For best performance the metadata should be on a different spindle
+    than the data, or even better on an SSD.
+
+    If setting up a new metadata pool it is required to be valid. This
+    can be achieved by zeroing the first 4k to indicate empty
+    metadata, like this:
+
+    ``dd if=/dev/zero of=$metadata_dev bs=4096 count=1``
+
+    Example use:
+
+    ``docker -d --storage-opt dm.datadev=/dev/sdb1 --storage-opt dm.metadatadev=/dev/sdc1``
+
+ *  `dm.blocksize`
+
+    Specifies a custom blocksize to use for the thin pool.  The default
+    blocksize is 64K.
+
+    Example use:
+
+    ``docker -d --storage-opt dm.blocksize=512K``
+
+ *  `dm.blkdiscard`
+
+    Enables or disables the use of blkdiscard when removing
+    devicemapper devices. This is enabled by default (only) if using
+    loopback devices and is required to resparsify the loopback file
+    on image/container removal.
+
+    Disabling this on loopback can lead to *much* faster container
+    removal times, but will make the space used in /var/lib/docker
+    directory not be returned to the system for other use when
+    containers are removed.
+
+    Example use:
+
+    ``docker -d --storage-opt dm.blkdiscard=false``
+
+ *  `dm.override_udev_sync_check`
+
+    Overrides the `udev` synchronization checks between `devicemapper` and `udev`.
+    `udev` is the device manager for the Linux kernel.
+
+    To view the `udev` sync support of a Docker daemon that is using the
+    `devicemapper` driver, run:
+
+        $ docker info
+	[...]
+	 Udev Sync Supported: true
+	[...]
+
+    When `udev` sync support is `true`, then `devicemapper` and udev can
+    coordinate the activation and deactivation of devices for containers.
+
+    When `udev` sync support is `false`, a race condition occurs between
+    the`devicemapper` and `udev` during create and cleanup. The race condition
+    results in errors and failures. (For information on these failures, see
+    [docker#4036](https://github.com/docker/docker/issues/4036))
+
+    To allow the `docker` daemon to start, regardless of `udev` sync not being
+    supported, set `dm.override_udev_sync_check` to true:
+
+        $ docker -d --storage-opt dm.override_udev_sync_check=true
+
+    When this value is `true`, the  `devicemapper` continues and simply warns
+    you the errors are happening.
+
+    > **Note**: The ideal is to pursue a `docker` daemon and environment that
+    > does support synchronizing with `udev`. For further discussion on this
+    > topic, see [docker#4036](https://github.com/docker/docker/issues/4036).
+    > Otherwise, set this flag for migrating existing Docker daemons to a
+    > daemon with a supported environment.
+
+ *  `dm.use_deferred_removal`
+
+    Enables use of deferred device removal if libdm and kernel driver
+    support the mechanism.
+
+    Deferred device removal means that if device is busy when devices is
+    being removed/deactivated, then a deferred removal is scheduled on
+    device. And devices automatically goes away when last user of device
+    exits.
+
+    For example, when container exits, its associated thin device is
+    removed. If that devices has leaked into some other mount namespace
+    can can't be removed now, container exit will still be successful
+    and this option will just schedule device for deferred removal and
+    will not wait in a loop trying to remove a busy device.
+
+    Example use:
+
+    ``docker -d --storage-opt dm.use_deferred_removal=true``
+

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1364,6 +1364,14 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 		}
 	}
 
+	if devices.thinPoolDevice == "" {
+		if devices.metadataLoopFile != "" || devices.dataLoopFile != "" {
+			logrus.Errorf("WARNING: No --storage-opt dm.thinpooldev specified, using loopback; this configuration is strongly discouraged for production use")
+		} else {
+			logrus.Warnf("--storage-opt dm.thinpooldev is preferred over --storage-opt dm.datadev or dm.metadatadev")
+		}
+	}
+
 	// If we didn't just create the data or metadata image, we need to
 	// load the transaction id and migrate old metadata
 	if !createdLoopback {

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1209,6 +1209,63 @@ func (devices *DeviceSet) loadThinPoolLoopBackInfo() error {
 	return nil
 }
 
+// Determine the major and minor number of loopback device
+func getLoopMajorMinor(file *os.File) (uint64, uint64, error) {
+	stat, err := file.Stat()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	Dev := stat.Sys().(*syscall.Stat_t).Rdev
+	majorNum := major(Dev)
+	minorNum := minor(Dev)
+
+	logrus.Debugf("devmapper: Major:Minor for device: %s is:%v:%v", file.Name(), majorNum, minorNum)
+	return majorNum, minorNum, nil
+}
+
+func (devices *DeviceSet) loadThinPoolProperties() error {
+	poolDataMajor, poolDataMinor, poolMetadataMajor, poolMetadataMinor, err := devices.getThinPoolDataMetaMajMin()
+	if err != nil {
+		return err
+	}
+
+	dirname := devices.loopbackDir()
+
+	// data device has not been passed in. So there should be a data file
+	// which is being mounted as loop device.
+	if devices.dataDevice == "" {
+		datafilename := path.Join(dirname, "data")
+		dataLoopDevice, dataMajor, dataMinor, err := getLoopFileDeviceMajMin(datafilename)
+		if err != nil {
+			return err
+		}
+
+		// Compare the two
+		if poolDataMajor == dataMajor && poolDataMinor == dataMinor {
+			devices.dataDevice = dataLoopDevice
+			devices.dataLoopFile = datafilename
+		}
+
+	}
+
+	// metadata device has not been passed in. So there should be a
+	// metadata file which is being mounted as loop device.
+	if devices.metadataDevice == "" {
+		metadatafilename := path.Join(dirname, "metadata")
+		metadataLoopDevice, metadataMajor, metadataMinor, err := getLoopFileDeviceMajMin(metadatafilename)
+		if err != nil {
+			return err
+		}
+		if poolMetadataMajor == metadataMajor && poolMetadataMinor == metadataMinor {
+			devices.metadataDevice = metadataLoopDevice
+			devices.metadataLoopFile = metadatafilename
+		}
+	}
+
+	return nil
+}
+
 func (devices *DeviceSet) initDevmapper(doInit bool) error {
 	// give ourselves to libdm as a log handler
 	devicemapper.LogInit(devices)
@@ -1369,6 +1426,17 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 			logrus.Errorf("WARNING: No --storage-opt dm.thinpooldev specified, using loopback; this configuration is strongly discouraged for production use")
 		} else {
 			logrus.Warnf("--storage-opt dm.thinpooldev is preferred over --storage-opt dm.datadev or dm.metadatadev")
+		}
+	}
+
+	// Pool already exists and caller did not pass us a pool. That means
+	// we probably created pool earlier and could not remove it as some
+	// containers were still using it. Detect some of the properties of
+	// pool, like is it using loop devices.
+	if info.Exists != 0 && devices.thinPoolDevice == "" {
+		if err := devices.loadThinPoolProperties(); err != nil {
+			logrus.Debugf("Failed to load thin pool properties:%v", err)
+			return err
 		}
 	}
 

--- a/daemon/secrets.go
+++ b/daemon/secrets.go
@@ -1,0 +1,86 @@
+package daemon
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+type Secret struct {
+	Name      string
+	IsDir     bool
+	HostBased bool
+}
+
+type SecretData struct {
+	Name string
+	Data []byte
+}
+
+func (s SecretData) SaveTo(dir string) error {
+	path := filepath.Join(dir, s.Name)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil && !os.IsExist(err) {
+		return err
+	}
+	if err := ioutil.WriteFile(path, s.Data, 0755); err != nil {
+		return err
+	}
+	return nil
+}
+
+func readAll(root, prefix string) ([]SecretData, error) {
+	path := filepath.Join(root, prefix)
+
+	data := []SecretData{}
+
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return data, nil
+		}
+
+		return nil, err
+	}
+
+	for _, f := range files {
+		fileData, err := readFile(root, filepath.Join(prefix, f.Name()))
+		if err != nil {
+			// If the file did not exist, might be a dangling symlink
+			// Ignore the error
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		data = append(data, fileData...)
+	}
+
+	return data, nil
+}
+
+func readFile(root, name string) ([]SecretData, error) {
+	path := filepath.Join(root, name)
+
+	s, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.IsDir() {
+		dirData, err := readAll(root, name)
+		if err != nil {
+			return nil, err
+		}
+		return dirData, nil
+	} else {
+		bytes, err := ioutil.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		return []SecretData{{Name: name, Data: bytes}}, nil
+	}
+}
+
+func getHostSecretData() ([]SecretData, error) {
+	return readAll("/usr/share/rhel/secrets", "")
+}

--- a/daemon/utils_unix.go
+++ b/daemon/utils_unix.go
@@ -5,6 +5,7 @@ package daemon
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/docker/docker/runconfig"
@@ -49,4 +50,13 @@ func mergeLxcConfIntoOptions(hostConfig *runconfig.HostConfig) ([]string, error)
 
 func convertUUID(id string) string {
 	return fmt.Sprintf("%s-%s-%s-%s-%.12s", id[0:8], id[8:12], id[12:16], id[16:20], id[20:])
+}
+
+func journalPath(id string) string {
+	finfo, err := os.Stat("/var/log/journal")
+	if err != nil || !finfo.IsDir() {
+		return ""
+	}
+
+	return fmt.Sprintf("/var/log/journal/%.32s", id)
 }

--- a/daemon/utils_unix.go
+++ b/daemon/utils_unix.go
@@ -46,3 +46,7 @@ func mergeLxcConfIntoOptions(hostConfig *runconfig.HostConfig) ([]string, error)
 
 	return out, nil
 }
+
+func convertUUID(id string) string {
+	return fmt.Sprintf("%s-%s-%s-%s-%.12s", id[0:8], id[8:12], id[12:16], id[16:20], id[20:])
+}

--- a/daemon/volumes_linux.go
+++ b/daemon/volumes_linux.go
@@ -31,6 +31,18 @@ func copyOwnership(source, destination string) error {
 
 func (container *Container) setupMounts() ([]execdriver.Mount, error) {
 	var mounts []execdriver.Mount
+
+	secretsPath, err := container.secretsPath()
+	if err != nil {
+		return nil, err
+	}
+
+	mounts = append(mounts, execdriver.Mount{
+		Source:      secretsPath,
+		Destination: "/run/secrets",
+		Writable:    true,
+	})
+
 	for _, m := range container.MountPoints {
 		path, err := m.Setup()
 		if err != nil {

--- a/daemon/volumes_linux.go
+++ b/daemon/volumes_linux.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/volume"
 	"github.com/docker/docker/volume/local"
+	"github.com/opencontainers/runc/libcontainer/label"
 )
 
 // copyOwnership copies the permissions and uid:gid of the source file
@@ -54,6 +55,31 @@ func (container *Container) setupMounts() ([]execdriver.Mount, error) {
 				Destination: m.Destination,
 				Writable:    m.RW,
 			})
+		}
+	}
+
+	if container.Config.Init == "systemd" {
+		if container.MountPoints["/run"] == nil {
+			mounts = append(mounts, execdriver.Mount{Source: "tmpfs", Destination: "/run", Writable: true, Private: true})
+		}
+
+		if container.MountPoints["/sys"] == nil &&
+			container.MountPoints["/sys/fs"] == nil &&
+			container.MountPoints["/sys/fs/cgroup"] == nil {
+			mounts = append(mounts, execdriver.Mount{Source: "/sys/fs/cgroup", Destination: "/sys/fs/cgroup", Writable: false, Private: true})
+		}
+
+		if container.MountPoints["/var"] == nil &&
+			container.MountPoints["/var/log"] == nil &&
+			container.MountPoints["/var/log/journal"] == nil {
+			if journalPath, err := container.setupJournal(); err != nil {
+				return nil, err
+			} else {
+				if journalPath != "" {
+					label.Relabel(journalPath, container.MountLabel, "Z")
+					mounts = append(mounts, execdriver.Mount{Source: journalPath, Destination: journalPath, Writable: true, Private: true})
+				}
+			}
 		}
 	}
 
@@ -129,4 +155,14 @@ func validVolumeLayout(files []os.FileInfo) bool {
 	}
 
 	return true
+}
+
+func (container *Container) setupJournal() (string, error) {
+	path := journalPath(container.ID)
+	if path != "" {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			return "", err
+		}
+	}
+	return path, nil
 }

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -66,6 +66,7 @@ following options.
  - [Container Identification](#container-identification)
      - [Name (--name)](#name-name)
      - [PID Equivalent](#pid-equivalent)
+ - [INIT Settings (--init)](#ipc-settings-ipc)
  - [IPC Settings (--ipc)](#ipc-settings-ipc)
  - [Network Settings](#network-settings)
  - [Restart Policies (--restart)](#restart-policies-restart)
@@ -200,6 +201,14 @@ more advanced use case would be changing the host's hostname from a container.
 
 > **Note**: `--uts="host"` gives the container full access to change the
 > hostname of the host and is therefore considered insecure.
+
+## INIT settings (--init)
+   Default to docker standard method of running containers.
+   	      'systemd': Changes the way docker runs a container, based on the systemd container specification.
+	      * Mounts "/run" as a tmpfs,
+	      * mounts /sys/fs/cgroup into the container as a read/only volume
+	      * Adds container_uuid environment variable.
+	      * Sets up volume mount /var/log/journald/UUID. Allowing journald data within the container to be seen by the host journalctl. 
 
 ## IPC settings (--ipc)
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1067,6 +1067,7 @@ container by using one or more `-e` flags, even overriding those mentioned
 above, or already defined by the developer with a Dockerfile `ENV`:
 
     $ docker run -e "deep=purple" --rm ubuntu /bin/bash -c export
+    declare -x container_uuid="be84194d-87f9-08c2-b2e1-67311f4409f5"
     declare -x HOME="/"
     declare -x HOSTNAME="85bc26a0e200"
     declare -x OLDPWD

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -29,6 +29,7 @@ docker-create - Create a new container
 [**-h**|**--hostname**[=*HOSTNAME*]]
 [**--help**]
 [**-i**|**--interactive**[=*false*]]
+[**--init**[=*INITSYSTEM*]]
 [**--ipc**[=*IPC*]]
 [**-l**|**--label**[=*[]*]]
 [**--label-file**[=*[]*]]
@@ -142,6 +143,14 @@ two memory nodes.
 
 **-i**, **--interactive**=*true*|*false*
    Keep STDIN open even if not attached. The default is *false*.
+
+**--init**=""
+   Default to docker standard method of running containers.
+   	      'systemd': Changes the way docker runs a container, based on the systemd container specification.
+	      * Mounts "/run" as a tmpfs,
+	      * mounts /sys/fs/cgroup into the container as a read/only volume
+	      * Adds container_uuid environment variable.
+	      * Sets up volume mount /var/log/journald/UUID. Allowing journald data within the container to be seen by the host journalctl. 
 
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -30,6 +30,7 @@ docker-run - Run a command in a new container
 [**-h**|**--hostname**[=*HOSTNAME*]]
 [**--help**]
 [**-i**|**--interactive**[=*false*]]
+[**--init**[=*INITSYSTEM*]]
 [**--ipc**[=*IPC*]]
 [**-l**|**--label**[=*[]*]]
 [**--label-file**[=*[]*]]
@@ -236,6 +237,14 @@ ENTRYPOINT.
    Keep STDIN open even if not attached. The default is *false*.
 
    When set to true, keep stdin open even if not attached. The default is false.
+
+**--init**=""
+   Default to docker standard method of running containers.
+   	      'systemd': Changes the way docker runs a container, based on the systemd container specification.
+	      * Mounts "/run" as a tmpfs,
+	      * mounts /sys/fs/cgroup into the container as a read/only volume
+	      * Adds container_uuid environment variable.
+	      * Sets up volume mount /var/log/journald/UUID. Allowing journald data within the container to be seen by the host journalctl. 
 
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -198,6 +198,9 @@ is the case the **--dns** flags is necessary for every run.
 environment variables that are available for the process that will be launched
 inside of the container.
 
+   The container_uuid is set automatically with a 32 character truncated
+Container ID in standard UUID format.
+
 **--entrypoint**=""
    Overwrite the default ENTRYPOINT of the image
 
@@ -565,6 +568,7 @@ Running the **env** command in the linker container shows environment variables
  with the LT (alias) context (**LT_**)
 
     # env
+    container_uuid=be84194d-87f9-08c2-b2e1-67311f4409f5
     HOSTNAME=668231cb0978
     TERM=xterm
     LT_PORT_80_TCP=tcp://172.17.0.3:80

--- a/patches/Centos.patch
+++ b/patches/Centos.patch
@@ -1,0 +1,64 @@
+diff --git a/Dockerfile b/Dockerfile
+index 434c0d2..5c9a238 100644
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -23,16 +23,20 @@
+ # the case. Therefore, you don't have to disable it anymore.
+ #
+ 
+-FROM ubuntu:14.04
++FROM centos7
+ MAINTAINER Tianon Gravi <admwiggin@gmail.com> (@tianon)
+ 
+-RUN	apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys E871F18B51E0147C77796AC81196BA81F6B0FC61
+-RUN	echo deb http://ppa.launchpad.net/zfs-native/stable/ubuntu trusty main > /etc/apt/sources.list.d/zfs.list
+-
+-# Packaged dependencies
+-RUN apt-get update && apt-get install -y \
+-	apparmor \
+-	aufs-tools \
++RUN yum -y update && yum install -y \
++	btrfs-progs-devel \
++	gcc \
++	glibc-static \
++	libcap-devel \
++	libsqlite3x-devel \
++        make \
++	python-websocket-client \
++	ruby \
++	ruby-dev \
++	tar \
+ 	automake \
+ 	bash-completion \
+ 	btrfs-tools \
+@@ -41,21 +45,14 @@ RUN apt-get update && apt-get install -y \
+ 	dpkg-sig \
+ 	git \
+ 	iptables \
+-	libapparmor-dev \
+-	libcap-dev \
+-	libsqlite3-dev \
+ 	mercurial \
+ 	parallel \
+ 	python-mock \
+ 	python-pip \
+-	python-websocket \
+ 	reprepro \
+-	ruby1.9.1 \
+-	ruby1.9.1-dev \
+ 	s3cmd=1.1.0* \
+ 	ubuntu-zfs \
+ 	libzfs-dev \
+-	--no-install-recommends
+ 
+ # Get lvm2 source for compiling statically
+ RUN git clone -b v2_02_103 https://git.fedorahosted.org/git/lvm2.git /usr/local/lvm2
+@@ -151,7 +148,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
+ 
+ VOLUME /var/lib/docker
+ WORKDIR /go/src/github.com/docker/docker
+-ENV DOCKER_BUILDTAGS apparmor selinux
++ENV DOCKER_BUILDTAGS selinux
+ 
+ # Let us use a .bashrc file
+ RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/patches/Fedora.patch
+++ b/patches/Fedora.patch
@@ -1,0 +1,64 @@
+diff --git a/Dockerfile b/Dockerfile
+index 434c0d2..5c9a238 100644
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -23,16 +23,20 @@
+ # the case. Therefore, you don't have to disable it anymore.
+ #
+ 
+-FROM ubuntu:14.04
++FROM fedora
+ MAINTAINER Tianon Gravi <admwiggin@gmail.com> (@tianon)
+ 
+-RUN	apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys E871F18B51E0147C77796AC81196BA81F6B0FC61
+-RUN	echo deb http://ppa.launchpad.net/zfs-native/stable/ubuntu trusty main > /etc/apt/sources.list.d/zfs.list
+-
+-# Packaged dependencies
+-RUN apt-get update && apt-get install -y \
+-	apparmor \
+-	aufs-tools \
++RUN yum -y update && yum install -y \
++	btrfs-progs-devel \
++	gcc \
++	glibc-static \
++	libcap-devel \
++	libsqlite3x-devel \
++        make \
++	python-websocket-client \
++	ruby \
++	ruby-dev \
++	tar \
+ 	automake \
+ 	bash-completion \
+ 	btrfs-tools \
+@@ -41,21 +45,14 @@ RUN apt-get update && apt-get install -y \
+ 	dpkg-sig \
+ 	git \
+ 	iptables \
+-	libapparmor-dev \
+-	libcap-dev \
+-	libsqlite3-dev \
+ 	mercurial \
+ 	parallel \
+ 	python-mock \
+ 	python-pip \
+-	python-websocket \
+ 	reprepro \
+-	ruby1.9.1 \
+-	ruby1.9.1-dev \
+ 	s3cmd=1.1.0* \
+ 	ubuntu-zfs \
+ 	libzfs-dev \
+-	--no-install-recommends
+ 
+ # Get lvm2 source for compiling statically
+ RUN git clone -b v2_02_103 https://git.fedorahosted.org/git/lvm2.git /usr/local/lvm2
+@@ -151,7 +148,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
+ 
+ VOLUME /var/lib/docker
+ WORKDIR /go/src/github.com/docker/docker
+-ENV DOCKER_BUILDTAGS apparmor selinux
++ENV DOCKER_BUILDTAGS selinux
+ 
+ # Let us use a .bashrc file
+ RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/patches/RHEL.patch
+++ b/patches/RHEL.patch
@@ -1,0 +1,64 @@
+diff --git a/Dockerfile b/Dockerfile
+index 434c0d2..5c9a238 100644
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -23,16 +23,20 @@
+ # the case. Therefore, you don't have to disable it anymore.
+ #
+ 
+-FROM ubuntu:14.04
++FROM rhel7
+ MAINTAINER Tianon Gravi <admwiggin@gmail.com> (@tianon)
+ 
+-RUN	apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys E871F18B51E0147C77796AC81196BA81F6B0FC61
+-RUN	echo deb http://ppa.launchpad.net/zfs-native/stable/ubuntu trusty main > /etc/apt/sources.list.d/zfs.list
+-
+-# Packaged dependencies
+-RUN apt-get update && apt-get install -y \
+-	apparmor \
+-	aufs-tools \
++RUN yum -y update && yum install -y \
++	btrfs-progs-devel \
++	gcc \
++	glibc-static \
++	libcap-devel \
++	libsqlite3x-devel \
++        make \
++	python-websocket-client \
++	ruby \
++	ruby-dev \
++	tar \
+ 	automake \
+ 	bash-completion \
+ 	btrfs-tools \
+@@ -41,21 +45,14 @@ RUN apt-get update && apt-get install -y \
+ 	dpkg-sig \
+ 	git \
+ 	iptables \
+-	libapparmor-dev \
+-	libcap-dev \
+-	libsqlite3-dev \
+ 	mercurial \
+ 	parallel \
+ 	python-mock \
+ 	python-pip \
+-	python-websocket \
+ 	reprepro \
+-	ruby1.9.1 \
+-	ruby1.9.1-dev \
+ 	s3cmd=1.1.0* \
+ 	ubuntu-zfs \
+ 	libzfs-dev \
+-	--no-install-recommends
+ 
+ # Get lvm2 source for compiling statically
+ RUN git clone -b v2_02_103 https://git.fedorahosted.org/git/lvm2.git /usr/local/lvm2
+@@ -151,7 +148,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
+ 
+ VOLUME /var/lib/docker
+ WORKDIR /go/src/github.com/docker/docker
+-ENV DOCKER_BUILDTAGS apparmor selinux
++ENV DOCKER_BUILDTAGS selinux
+ 
+ # Let us use a .bashrc file
+ RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/patches/gen_dockerfile.go
+++ b/patches/gen_dockerfile.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func genDockerfile() (string, error) {
+	file, err := os.Open("/etc/redhat-release")
+	if err != nil {
+		return "Dockerfile", nil
+	}
+	defer file.Close()
+	reader := bufio.NewReader(file)
+	scanner := bufio.NewScanner(reader)
+	scanner.Scan()
+	line := strings.Split(scanner.Text(), " ")
+	os_str := line[0]
+	switch os_str {
+	case "Fedora", "Centos":
+		break
+	case "red":
+		os_str = "RHEL"
+		break
+
+	default:
+		return "Dockerfile", nil
+	}
+	if err := patchDockerfile(os_str); err != nil {
+		return "", err
+	}
+	return "patches/Dockerfile" + os_str, nil
+}
+
+func patchDockerfile(os_name string) error {
+	patchStr := "patch -p1 -o patches/Dockerfile" + os_name + " < patches/" + os_name + ".patch"
+	patcher := []string{"-c", patchStr}
+	c := exec.Command("/bin/sh", patcher...)
+	out, err := c.CombinedOutput()
+	if err != nil {
+		fmt.Println(string(out), err)
+	}
+	return err
+}
+
+func main() {
+
+	dockerfile, err := genDockerfile()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(dockerfile)
+
+}

--- a/pkg/rpm/rpm.go
+++ b/pkg/rpm/rpm.go
@@ -1,0 +1,19 @@
+package rpm
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func Version(name string) (string, error) {
+	var (
+		err    error
+		out    []byte
+		option = "-q"
+	)
+	if name[0] == '/' {
+		option = "-qf"
+	}
+	out, err = exec.Command("/usr/bin/rpm", option, name).Output()
+	return strings.Trim(string(out), "\n"), err
+}

--- a/pkg/systemd/register.go
+++ b/pkg/systemd/register.go
@@ -1,0 +1,56 @@
+// +build linux
+
+package systemd
+
+import (
+	"encoding/hex"
+	"github.com/godbus/dbus"
+)
+
+var conn *dbus.Conn
+
+// RegisterMachine with systemd on the host system
+func RegisterMachine(name string, id string, pid int, root_directory string) error {
+	var (
+		av  []byte
+		err error
+	)
+	if !SdBooted() {
+		return nil
+	}
+
+	if conn == nil {
+		conn, err = dbus.SystemBus()
+		if err != nil {
+			return (err)
+		}
+	}
+
+	av, err = hex.DecodeString(id[0:32])
+	if err != nil {
+		return err
+	}
+
+	obj := conn.Object("org.freedesktop.machine1", "/org/freedesktop/machine1")
+	return obj.Call("org.freedesktop.machine1.Manager.RegisterMachine", 0, name[0:64], av, "docker", "container", uint32(pid), root_directory).Err
+}
+
+// TerminateMachine registered with systemd on the host system
+func TerminateMachine(name string) error {
+	var (
+		err error
+	)
+	if !SdBooted() {
+		return nil
+	}
+
+	if conn == nil {
+		conn, err = dbus.SystemBus()
+		if err != nil {
+			return (err)
+		}
+	}
+
+	obj := conn.Object("org.freedesktop.machine1", "/org/freedesktop/machine1")
+	return obj.Call("org.freedesktop.machine1.Manager.TerminateMachine", 0, name).Err
+}

--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -303,6 +303,8 @@ by having support for them in the kernel or userspace. A few examples include:
   least the "auplink" utility from aufs-tools)
 * BTRFS graph driver (requires BTRFS support enabled in the kernel)
 * ZFS graph driver (requires userspace zfs-utils and a corresponding kernel module)
+* Restriction of inter-container communication (requires `br_netfilter` module 
+  loaded or compiled in).
 
 ## Daemon Init Script
 

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -137,6 +137,7 @@ type Config struct {
 	MacAddress      string
 	OnBuild         []string
 	Labels          map[string]string
+	Init            string
 }
 
 type ContainerConfigWrapper struct {

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -94,6 +94,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flLoggingDriver   = cmd.String([]string{"-log-driver"}, "", "Logging driver for container")
 		flCgroupParent    = cmd.String([]string{"-cgroup-parent"}, "", "Optional parent cgroup for the container")
 		flVolumeDriver    = cmd.String([]string{"-volume-driver"}, "", "Optional volume driver for the container")
+		flInit            = cmd.String([]string{"-init"}, "", "Run container following specified init system container method (systemd)")
 	)
 
 	cmd.Var(&flAttach, []string{"a", "-attach"}, "Attach to STDIN, STDOUT or STDERR")
@@ -336,6 +337,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		WorkingDir:      *flWorkingDir,
 		Labels:          convertKVStringsToMap(labels),
 		VolumeDriver:    *flVolumeDriver,
+		Init:            *flInit,
 	}
 
 	hostConfig := &HostConfig{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -286,3 +286,8 @@ func ImageReference(repo, ref string) string {
 func DigestReference(ref string) bool {
 	return strings.Contains(ref, ":")
 }
+
+func RunningInsideDockerContainer() bool {
+	_, err := os.Stat("/.dockerinit")
+	return !os.IsNotExist(err)
+}

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/init_linux.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/init_linux.go
@@ -13,7 +13,6 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/netlink"
-	"github.com/opencontainers/runc/libcontainer/seccomp"
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/opencontainers/runc/libcontainer/utils"
@@ -269,62 +268,4 @@ func killCgroupProcesses(m cgroups.Manager) error {
 		}
 	}
 	return nil
-}
-
-func finalizeSeccomp(config *initConfig) error {
-	if config.Config.Seccomp == nil {
-		return nil
-	}
-	context := seccomp.New()
-	for _, s := range config.Config.Seccomp.Syscalls {
-		ss := &seccomp.Syscall{
-			Value:  uint32(s.Value),
-			Action: seccompAction(s.Action),
-		}
-		if len(s.Args) > 0 {
-			ss.Args = seccompArgs(s.Args)
-		}
-		context.Add(ss)
-	}
-	return context.Load()
-}
-
-func seccompAction(a configs.Action) seccomp.Action {
-	switch a {
-	case configs.Kill:
-		return seccomp.Kill
-	case configs.Trap:
-		return seccomp.Trap
-	case configs.Allow:
-		return seccomp.Allow
-	}
-	return seccomp.Error(syscall.Errno(int(a)))
-}
-
-func seccompArgs(args []*configs.Arg) seccomp.Args {
-	var sa []seccomp.Arg
-	for _, a := range args {
-		sa = append(sa, seccomp.Arg{
-			Index: uint32(a.Index),
-			Op:    seccompOperator(a.Op),
-			Value: uint(a.Value),
-		})
-	}
-	return seccomp.Args{sa}
-}
-
-func seccompOperator(o configs.Operator) seccomp.Operator {
-	switch o {
-	case configs.EqualTo:
-		return seccomp.EqualTo
-	case configs.NotEqualTo:
-		return seccomp.NotEqualTo
-	case configs.GreatherThan:
-		return seccomp.GreatherThan
-	case configs.LessThan:
-		return seccomp.LessThan
-	case configs.MaskEqualTo:
-		return seccomp.MaskEqualTo
-	}
-	return 0
 }

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/standard_init_linux.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/standard_init_linux.go
@@ -99,8 +99,5 @@ func (l *linuxStandardInit) Init() error {
 	if syscall.Getppid() != l.parentPid {
 		return syscall.Kill(syscall.Getpid(), syscall.SIGKILL)
 	}
-	if err := finalizeSeccomp(l.config); err != nil {
-		return err
-	}
 	return system.Execv(l.config.Args[0], l.config.Args[0:], os.Environ())
 }


### PR DESCRIPTION
Will be superceded by the libseccomp patches, whenever Docker accepts them.