### PR TITLE
Fixed push of unqualified image

### DIFF
--- a/graph/push.go
+++ b/graph/push.go
@@ -117,9 +117,10 @@ func (s *TagStore) Push(localName string, imagePushConfig *ImagePushConfig) erro
 
 	imagePushConfig.OutStream.Write(sf.FormatStatus("", "The push refers to a repository [%s] (len: %d)", repoInfo.CanonicalName, reposLen))
 	matching := s.getRepositoryList(localName)
+Loop:
 	for _, namedRepo := range matching {
 		for _, localRepo = range namedRepo {
-			break
+			break Loop
 		}
 	}
 	if localRepo == nil {

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -393,13 +393,20 @@ func (store *TagStore) SetDigest(repoName, digest, imageName string, keepUnquali
 // *Default registry* here means any registry in registry.RegistryList.
 // Returned is a list of maps with just one entry {"repositoryName": Repository}
 func (store *TagStore) getRepositoryList(repoName string) (result []map[string]Repository) {
-	if r, exists := store.Repositories[repoName]; exists {
-		result = []map[string]Repository{
-			{repoName: r},
+	repoMap := map[string]struct{}{}
+	addResult := func(name string, repo Repository) bool {
+		if _, exists := repoMap[name]; exists {
+			return false
 		}
+		result = append(result, map[string]Repository{name: repo})
+		repoMap[name] = struct{}{}
+		return true
+	}
+	if r, exists := store.Repositories[repoName]; exists {
+		addResult(repoName, r)
 	}
 	if r, exists := store.Repositories[registry.NormalizeLocalName(repoName)]; exists {
-		result = append(result, map[string]Repository{registry.NormalizeLocalName(repoName): r})
+		addResult(registry.NormalizeLocalName(repoName), r)
 	}
 	if !registry.RepositoryNameHasIndex(repoName) {
 		defaultRegistries := make(map[string]struct{}, len(registry.RegistryList))
@@ -410,14 +417,14 @@ func (store *TagStore) getRepositoryList(repoName string) (result []map[string]R
 			}
 			fqn := registry.NormalizeLocalName(registry.RegistryList[i] + "/" + repoName)
 			if r, exists := store.Repositories[fqn]; exists {
-				result = append(result, map[string]Repository{fqn: r})
+				addResult(fqn, r)
 			}
 		}
 		for name, r := range store.Repositories {
 			indexName, remoteName := registry.SplitReposName(name, false)
 			if indexName != "" && remoteName == repoName {
 				if _, exists := defaultRegistries[indexName]; exists {
-					result = append(result, map[string]Repository{name: r})
+					addResult(name, r)
 				}
 			}
 		}

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -672,3 +672,29 @@ func (s *DockerRegistrySuite) TestPushToAdditionalRegistry(c *check.C) {
 	}
 	d.getAndTestImageEntry(c, 1, s.reg.url+"/library/busybox", busyboxID)
 }
+
+func (s *DockerRegistrySuite) TestPushCustomTagToAdditionalRegistry(c *check.C) {
+	d := NewDaemon(c)
+	if err := d.StartWithBusybox("--add-registry=" + s.reg.url); err != nil {
+		c.Fatalf("we should have been able to start the daemon with passing add-registry=%s: %v", s.reg.url, err)
+	}
+	defer d.Stop()
+
+	busyboxID := d.getAndTestImageEntry(c, 1, "busybox", "").id
+
+	if out, err := d.Cmd("tag", "busybox", "user/busybox:1.2.3"); err != nil {
+		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
+	}
+	if out, err := d.Cmd("tag", "busybox", s.reg.url+"/user/busybox:latest"); err != nil {
+		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
+	}
+	if out, err := d.Cmd("push", "user/busybox:1.2.3"); err != nil {
+		c.Fatalf("failed to push image user/busybox: error %v, output %q", err, out)
+	}
+	d.getAndTestImageEntry(c, 3, "user/busybox", busyboxID)
+	toRemove := []string{"user/busybox:1.2.3"}
+	if out, err := d.Cmd("rmi", toRemove...); err != nil {
+		c.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
+	}
+	d.getAndTestImageEntry(c, 2, s.reg.url+"/user/busybox", busyboxID)
+}

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -341,7 +341,7 @@ func (d *Daemon) buildImageWithOut(name, dockerfile string, useCache bool) (stri
 
 // List images of given Docker daemon and return it in a map[repoName]=*LocaleImageEntry.
 func (d *Daemon) getImages(c *check.C, args ...string) map[string]*localImageEntry {
-	reImageEntry := regexp.MustCompile(`(?m)^([[:alnum:]/.:_-]+)\s+(\w+)\s+([a-fA-F0-9]+)\s+`)
+	reImageEntry := regexp.MustCompile(`(?m)^([[:alnum:]/.:_-]+)\s+([[:alnum:]._-]+)\s+([a-fA-F0-9]+)\s+`)
 	result := make(map[string]*localImageEntry)
 
 	out, err := d.Cmd("images", append([]string{"--no-trunc"}, args...)...)


### PR DESCRIPTION
This fixes a case where there is fully qualified and unqualified
repository with the same name in Docker's local storage e.g:

    user/repo
    default.registry.io/user/repo

Fully qualified repository was always preferred over the unqualified.

Resolves: [bz#1241950](https://bugzilla.redhat.com/show_bug.cgi?id=1241950)