### PR TITLE
Fix error when trying to delete an image due to a bad container

### DIFF
--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/graph"
 	"github.com/docker/docker/image"
@@ -141,6 +142,16 @@ func (daemon *Daemon) imgDeleteHelper(name string, list *[]types.ImageDelete, fi
 
 func (daemon *Daemon) canDeleteImage(imgID string, force bool) error {
 	for _, container := range daemon.List() {
+		if container.ImageID == "" {
+			// This technically should never happen, but if the container
+			// has no ImageID then log the situation and move on.
+			// If we allowed processing to continue then the code later
+			// on would fail with a "Prefix can't be empty" error even
+			// though the bad container has nothing to do with the image
+			// we're trying to delete.
+			logrus.Errorf("Container %q has no image associated with it!", container.ID)
+			continue
+		}
 		parent, err := daemon.Repositories().LookupImage(container.ImageID)
 		if err != nil {
 			if daemon.Graph().IsNotExist(err, container.ImageID) {


### PR DESCRIPTION
> I ran into a situation where I was trying:
> 	`docker rmi busybox`
> and it kept failing saying:
>     `could not find image: Prefix can't be empty`
> 
> While I have no idea how I got into this situation, it turns out this is
> error message is from `daemon.canDeleteImage()`. In that func we loop over
> all containers checking to see if they're using the image we're trying to
> delete.  In my case though, I had a container with no ImageID. So the code
> would die tryig to find that image (hence the "Prefix can't be empty" err).
> This would stop all processing despite the fact that the container we're
> checking had nothing to do with 'busybox'.
> 
> My change logs the bad situation in the logs and then skips that container.
> There's no reason to fail all `docker rmi ...` calls just because of one
> bad container.
> 
> Will continue to try to figure out how I got a container w/o an ImageID
> but as of now I have no idea, I didn't do anything but normal docker cli
> commands.

Resolves [rhbz#1258889](https://bugzilla.redhat.com/show_bug.cgi?id=1258889)
