### PR TITLE
Note API calls to syslog and the audit log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get install -y \
 	dpkg-sig \
 	gcc-mingw-w64 \
 	libapparmor-dev \
+	libaudit-dev \
 	libcap-dev \
 	libsqlite3-dev \
 	python-websocket \

--- a/api/server/credentials_linux.go
+++ b/api/server/credentials_linux.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/daemon"
+	"github.com/docker/docker/pkg/audit"
 )
 
 //Gets the file descriptor
@@ -142,7 +143,11 @@ func generateContainerConfigMsg(c *daemon.Container, j *types.ContainerJSON) str
 
 //LogAction logs a docker API function and records the user that initiated the request using the authentication results
 func (s *Server) LogAction(w http.ResponseWriter, r *http.Request) error {
-	var message string
+	var (
+		message  string
+		username string
+		loginuid int
+	)
 	action, c := s.parseRequest(r)
 
 	switch action {
@@ -189,12 +194,13 @@ func (s *Server) LogAction(w http.ResponseWriter, r *http.Request) error {
 		message = fmt.Sprintf("Username=%v, %s", username, message)
 	}
 
-	//Provide the container ID being affected if it exists
+	//Log the container ID being affected if it exists
 	if c != nil {
 		message = fmt.Sprintf("ID=%v, %s", c.ID, message)
 	}
 	message = fmt.Sprintf("{Action=%v, %s}", action, message)
 	logSyslog(message)
+	logAuditlog(c, action, username, loginuid, true)
 	return nil
 }
 
@@ -207,4 +213,51 @@ func logSyslog(message string) {
 	}
 	logger.Info(message)
 	logger.Close()
+}
+
+//Logs an API event to the audit log
+func logAuditlog(c *daemon.Container, action string, username string, loginuid int, success bool) {
+	virt := audit.AUDIT_VIRT_CONTROL
+	vm := "?"
+	vm_pid := "?"
+	exe := "?"
+	hostname := "?"
+	user := "?"
+	auid := "?"
+
+	if c != nil {
+		vm = c.Config.Image
+		vm_pid = fmt.Sprint(c.State.Pid)
+		exe = c.Path
+		hostname = c.Config.Hostname
+	}
+
+	if username != "" {
+		user = username
+	}
+
+	if loginuid != -1 {
+		auid = fmt.Sprint(loginuid)
+	}
+
+	vars := map[string]string{
+		"op":       action,
+		"reason":   "api",
+		"vm":       vm,
+		"vm-pid":   vm_pid,
+		"user":     user,
+		"auid":     auid,
+		"exe":      exe,
+		"hostname": hostname,
+	}
+
+	//Encoding is a function of libaudit that ensures
+	//that the audit values contain only approved characters.
+	for key, value := range vars {
+		if audit.AuditValueNeedsEncoding(value) {
+			vars[key] = audit.AuditEncodeNVString(key, value)
+		}
+	}
+	message := audit.AuditFormatVars(vars)
+	audit.AuditLogUserEvent(virt, message, success)
 }

--- a/api/server/credentials_linux.go
+++ b/api/server/credentials_linux.go
@@ -1,0 +1,210 @@
+// +build linux
+
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log/syslog"
+	"net/http"
+	"net/url"
+	"os/user"
+	"path"
+	"reflect"
+	"strconv"
+	"syscall"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/daemon"
+)
+
+//Gets the file descriptor
+func getFdFromWriter(w http.ResponseWriter) int {
+	//We must use introspection to pull the
+	//connection from the ResponseWriter object
+	//This is because the connection object is not exported by the writer.
+	writerVal := reflect.Indirect(reflect.ValueOf(w))
+	//Get the underlying http connection
+	httpconn := writerVal.FieldByName("conn")
+	httpconnVal := reflect.Indirect(httpconn)
+	//Get the underlying tcp connection
+	rwcPtr := httpconnVal.FieldByName("rwc").Elem()
+	rwc := reflect.Indirect(rwcPtr)
+	tcpconn := reflect.Indirect(rwc.FieldByName("conn"))
+	//Grab the underyling netfd
+	netfd := reflect.Indirect(tcpconn.FieldByName("fd"))
+	//Grab sysfd
+	sysfd := netfd.FieldByName("sysfd")
+	//Finally, we have the fd
+	return int(sysfd.Int())
+}
+
+//Gets the ucred given an http response writer
+func getUcred(fd int) (*syscall.Ucred, error) {
+	return syscall.GetsockoptUcred(fd, syscall.SOL_SOCKET, syscall.SO_PEERCRED)
+}
+
+//Gets the client's loginuid
+func getLoginUID(ucred *syscall.Ucred, fd int) (int, error) {
+	if _, err := syscall.Getpeername(fd); err != nil {
+		logrus.Errorf("Socket appears to have closed: %v", err)
+		return -1, err
+	}
+	loginuid, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/loginuid", ucred.Pid))
+	if err != nil {
+		logrus.Errorf("Error reading loginuid: %v", err)
+		return -1, err
+	}
+	loginuidInt, err := strconv.Atoi(string(loginuid))
+	if err != nil {
+		logrus.Errorf("Failed to convert loginuid to int: %v", err)
+	}
+	return loginuidInt, nil
+}
+
+//Given a loginUID, retrieves the current username
+func getpwuid(loginUID int) (string, error) {
+	pwd, err := user.LookupId(strconv.Itoa(loginUID))
+	if err != nil {
+		logrus.Errorf("Failed to get pwuid struct: %v", err)
+		return "", err
+	}
+	if pwd == nil {
+		return "", user.UnknownUserIdError(loginUID)
+	}
+	name := pwd.Username
+	return name, nil
+}
+
+//Retrieves the container and "action" (start, stop, kill, etc) from the http request
+func (s *Server) parseRequest(r *http.Request) (string, *daemon.Container) {
+	var (
+		containerID string
+		action      string
+	)
+	requrl := r.RequestURI
+	parsedurl, err := url.Parse(requrl)
+	if err != nil {
+		return "?", nil
+	}
+
+	switch r.Method {
+	//Delete requests do not explicitly state the action, so we check the HTTP method instead
+	case "DELETE":
+		action = "remove"
+		containerID = path.Base(parsedurl.Path)
+	default:
+		action = path.Base(parsedurl.Path)
+		containerID = path.Base(path.Dir(parsedurl.Path))
+	}
+
+	c, err := s.daemon.Get(containerID)
+	if err != nil {
+		return action, nil
+	}
+	return action, c
+}
+
+//Traverses the config struct and grabs non-standard values for logging
+func parseConfig(config interface{}) string {
+	configReflect := reflect.Indirect(reflect.ValueOf(config))
+	var result bytes.Buffer
+	for index := 0; index < configReflect.NumField(); index++ {
+		val := reflect.Indirect(configReflect.Field(index))
+		//Get the zero value of the struct's field
+		if val.IsValid() {
+			zeroVal := reflect.Zero(val.Type()).Interface()
+			//If the configuration value is not a zero value, then we store it
+			//We use deep equal here because some types cannot be compared with the standard equality operators
+			if val.Kind() == reflect.Bool || !reflect.DeepEqual(zeroVal, val.Interface()) {
+				fieldName := configReflect.Type().Field(index).Name
+				if result.Len() > 0 {
+					result.WriteString(", ")
+				}
+				fmt.Fprintf(&result, "%s=%+v", fieldName, val.Interface())
+			}
+		}
+	}
+	return result.String()
+}
+
+//Constructs a partial log message containing the container's configuration settings
+func generateContainerConfigMsg(c *daemon.Container, j *types.ContainerJSON) string {
+	if c != nil && j != nil {
+		configStripped := parseConfig(*c.Config)
+		hostConfigStripped := parseConfig(*j.HostConfig)
+		return fmt.Sprintf("Config={%v}, HostConfig={%v}", configStripped, hostConfigStripped)
+	}
+	return ""
+}
+
+//LogAction logs a docker API function and records the user that initiated the request using the authentication results
+func (s *Server) LogAction(w http.ResponseWriter, r *http.Request) error {
+	var message string
+	action, c := s.parseRequest(r)
+
+	switch action {
+	case "start":
+		inspect, err := s.daemon.ContainerInspect(c.ID)
+		if err == nil {
+			message = ", " + generateContainerConfigMsg(c, inspect)
+		}
+		fallthrough
+	default:
+		//Get user credentials
+		fd := getFdFromWriter(w)
+		server, err := syscall.Getsockname(fd)
+		if err != nil {
+			logrus.Errorf("Unable to read peer creds and server socket address: %v", err)
+			message = "LoginUID unknown, PID unknown" + message
+			break
+		}
+		if _, isUnix := server.(*syscall.SockaddrUnix); !isUnix {
+			logrus.Debug("Unable to read peer creds: server socket is not a Unix socket")
+			message = "LoginUID unknown, PID unknown" + message
+			break
+		}
+		ucred, err := getUcred(fd)
+		if err != nil {
+			logrus.Errorf("Unable to read peer creds: %v", err)
+			message = "LoginUID unknown, PID unknown" + message
+			break
+		}
+		message = fmt.Sprintf("PID=%v", ucred.Pid) + message
+
+		//Get user loginuid
+		loginuid, err := getLoginUID(ucred, fd)
+		if err != nil {
+			break
+		}
+		message = fmt.Sprintf("LoginUID=%v, %s", loginuid, message)
+
+		//Get username
+		username, err := getpwuid(loginuid)
+		if err != nil {
+			break
+		}
+		message = fmt.Sprintf("Username=%v, %s", username, message)
+	}
+
+	//Provide the container ID being affected if it exists
+	if c != nil {
+		message = fmt.Sprintf("ID=%v, %s", c.ID, message)
+	}
+	message = fmt.Sprintf("{Action=%v, %s}", action, message)
+	logSyslog(message)
+	return nil
+}
+
+//Logs a message to the syslog
+func logSyslog(message string) {
+	logger, err := syslog.New(syslog.LOG_ALERT, "Docker")
+	if err != nil {
+		logrus.Errorf("Error logging %v to system log: %v", message, err)
+		return
+	}
+	logger.Info(message)
+	logger.Close()
+}

--- a/api/server/credentials_windows.go
+++ b/api/server/credentials_windows.go
@@ -1,0 +1,10 @@
+// +build windows
+
+package server
+
+import "net/http"
+
+//LogAction is unsupported in windows environments
+func (s *Server) LogAction(w http.ResponseWriter, r *http.Request) error {
+	return nil
+}

--- a/contrib/builder/deb/debian-jessie/Dockerfile
+++ b/contrib/builder/deb/debian-jessie/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM debian:jessie
 
-RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/debian-stretch/Dockerfile
+++ b/contrib/builder/deb/debian-stretch/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM debian:stretch
 
-RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/debian-wheezy/Dockerfile
+++ b/contrib/builder/deb/debian-wheezy/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM debian:wheezy-backports
 
-RUN apt-get update && apt-get install -y bash-completion btrfs-tools/wheezy-backports build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash-completion btrfs-tools/wheezy-backports build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/generate.sh
+++ b/contrib/builder/deb/generate.sh
@@ -53,6 +53,7 @@ for version in "${versions[@]}"; do
 		dh-systemd # for systemd debhelper integration
 		git # for "git commit" info in "docker -v"
 		libapparmor-dev # for "sys/apparmor.h"
+		libaudit-dev # for "libaudit.h" and libaudit.so
 		libdevmapper-dev # for "libdevmapper.h"
 		libsqlite3-dev # for "sqlite3.h"
 	)

--- a/contrib/builder/deb/ubuntu-precise/Dockerfile
+++ b/contrib/builder/deb/ubuntu-precise/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM ubuntu:precise
 
-RUN apt-get update && apt-get install -y bash-completion  build-essential curl ca-certificates debhelper  git libapparmor-dev  libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash-completion  build-essential curl ca-certificates debhelper  git libapparmor-dev libaudit-dev  libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/ubuntu-trusty/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM ubuntu:trusty
 
-RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/ubuntu-vivid/Dockerfile
+++ b/contrib/builder/deb/ubuntu-vivid/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM ubuntu:vivid
 
-RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/ubuntu-wily/Dockerfile
+++ b/contrib/builder/deb/ubuntu-wily/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM ubuntu:wily
 
-RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/rpm/centos-7/Dockerfile
+++ b/contrib/builder/rpm/centos-7/Dockerfile
@@ -6,7 +6,7 @@ FROM centos:7
 
 RUN yum groupinstall -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y audit-libs-devel audit-libs-static btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/rpm/fedora-21/Dockerfile
+++ b/contrib/builder/rpm/fedora-21/Dockerfile
@@ -5,7 +5,7 @@
 FROM fedora:21
 
 RUN yum install -y @development-tools fedora-packager
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y audit-libs-devel audit-libs-static btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/rpm/fedora-22/Dockerfile
+++ b/contrib/builder/rpm/fedora-22/Dockerfile
@@ -5,7 +5,7 @@
 FROM fedora:22
 
 RUN yum install -y @development-tools fedora-packager
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y audit-libs-devel audit-libs-static btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/rpm/generate.sh
+++ b/contrib/builder/rpm/generate.sh
@@ -54,6 +54,7 @@ for version in "${versions[@]}"; do
 
 	# this list is sorted alphabetically; please keep it that way
 	packages=(
+		audit-libs-devel audit-libs-static # for "libaudit.h" and libaudit.so/libaudit.a
 		btrfs-progs-devel # for "btrfs/ioctl.h" (and "version.h" if possible)
 		device-mapper-devel # for "libdevmapper.h"
 		glibc-static

--- a/contrib/builder/rpm/oraclelinux-6/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-6/Dockerfile
@@ -5,7 +5,7 @@
 FROM oraclelinux:6
 
 RUN yum groupinstall -y "Development Tools"
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y audit-libs-devel audit-libs-static btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/rpm/oraclelinux-7/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-7/Dockerfile
@@ -5,7 +5,7 @@
 FROM oraclelinux:7
 
 RUN yum groupinstall -y "Development Tools"
-RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y --enablerepo=ol7_optional_latest audit-libs-devel audit-libs-static btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
 ENV GO_VERSION 1.4.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/distribution/Centos.json
+++ b/distribution/Centos.json
@@ -2,6 +2,8 @@
     "distribution": "FROM centos",
     "dependencies":[
       "  RUN yum -y update && yum install -y \\",
+      "  audit-libs-devel \\",
+      "  audit-libs-static \\",
       "  binutils \\",
       "  btrfs-progs-devel \\",
       "  btrfs-progs \\",

--- a/distribution/DockerfileFedora
+++ b/distribution/DockerfileFedora
@@ -26,6 +26,8 @@
 # Cut for distribution specific
 FROM fedora
   RUN dnf -y update && dnf install -y \
+  audit-libs-devel \
+  audit-libs-static \
   binutils \
   btrfs-progs-devel \
   btrfs-progs \
@@ -158,7 +160,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT 8a87001d09852058f08a807ab6e8491d57ca1e88
+ENV DOCKER_PY_COMMIT 139850f3f3b17357bab5ba3edfb745fb14043764
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT

--- a/distribution/Fedora.json
+++ b/distribution/Fedora.json
@@ -2,6 +2,8 @@
     "distribution": "FROM fedora",
     "dependencies":[
       "  RUN dnf -y update && dnf install -y \\",
+      "  audit-libs-devel \\",
+      "  audit-libs-static \\",
       "  binutils \\",
       "  btrfs-progs-devel \\",
       "  btrfs-progs \\",

--- a/distribution/RHEL.json
+++ b/distribution/RHEL.json
@@ -2,6 +2,8 @@
     "distribution": "FROM rhel",
     "dependencies":[
       "  RUN yum -y update && yum install -y \\",
+      "  audit-libs-devel \\",
+      "  audit-libs-static \\",
       "  binutils \\",
       "  btrfs-progs-devel \\",
       "  btrfs-progs \\",

--- a/pkg/audit/audit_linux.go
+++ b/pkg/audit/audit_linux.go
@@ -1,0 +1,79 @@
+// +build linux
+/*
+  The audit package is a go bindings to libaudit that only allows for
+  logging audit events.
+
+  Author Steve Grubb <sgrubb@redhat.com>
+*/
+
+package audit
+
+// #cgo LDFLAGS: -laudit
+// #include "libaudit.h"
+// #include <unistd.h>
+// #include <stdlib.h>
+// #include <string.h>
+// #include <stdio.h>
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+const (
+	AUDIT_VIRT_CONTROL    = 2500
+	AUDIT_VIRT_RESOURCE   = 2501
+	AUDIT_VIRT_MACHINE_ID = 2502
+)
+
+func AuditValueNeedsEncoding(str string) bool {
+	cstr := C.CString(str)
+	defer C.free(unsafe.Pointer(cstr))
+	len := C.strlen(cstr)
+
+	res, _ := C.audit_value_needs_encoding(cstr, C.uint(len))
+	if res != 0 {
+		return true
+	}
+	return false
+}
+
+func AuditEncodeNVString(name string, value string) string {
+	cname := C.CString(name)
+	cval := C.CString(value)
+
+	cres := C.audit_encode_nv_string(cname, cval, 0)
+
+	C.free(unsafe.Pointer(cname))
+	C.free(unsafe.Pointer(cval))
+	defer C.free(unsafe.Pointer(cres))
+
+	return C.GoString(cres)
+}
+
+func AuditLogUserEvent(event_type int, message string, result bool) error {
+	var r int
+	fd := C.audit_open()
+	defer C.close(fd)
+	if result {
+		r = 1
+	} else {
+		r = 0
+	}
+	if fd > 0 {
+		cmsg := C.CString(message)
+		defer C.free(unsafe.Pointer(cmsg))
+		_, err := C.audit_log_user_message(fd, C.int(event_type), cmsg, nil, nil, nil, C.int(r))
+		return err
+	}
+	return nil
+}
+
+func AuditFormatVars(vars map[string]string) string {
+	var result string
+	for key, value := range vars {
+		result += fmt.Sprintf("%s=%s ", key, value)
+	}
+	return result
+}


### PR DESCRIPTION
These are changes from @alecbenson's PR#109 (for the fedora-1.8 branch), cherry-picked and with merge conflicts resolved.

We had to move from reading the host config directly from the container structure because the field is no longer public.  Instead, we take a bit of a hit by calling ContainerInspect(), which returns that data, along with some that we discard.