### PR TITLE
hD hooks

### DIFF
--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -147,24 +147,21 @@ func (d *Driver) createNetwork(container *configs.Config, c *execdriver.Command,
 	}
 	// only set up prestart hook if the namespace path is not set (this should be
 	// all cases *except* for --net=host shared networking)
-	container.Hooks = &configs.Hooks{
-		Prestart: []configs.Hook{
-			configs.NewFunctionHook(func(s configs.HookState) error {
-				if len(hooks.PreStart) > 0 {
-					for _, fnHook := range hooks.PreStart {
-						// A closed channel for OOM is returned here as it will be
-						// non-blocking and return the correct result when read.
-						chOOM := make(chan struct{})
-						close(chOOM)
-						if err := fnHook(&c.ProcessConfig, s.Pid, chOOM); err != nil {
-							return err
-						}
+	container.Hooks.Prestart = append(container.Hooks.Prestart,
+		configs.NewFunctionHook(func(s configs.HookState) error {
+			if len(hooks.PreStart) > 0 {
+				for _, fnHook := range hooks.PreStart {
+					// A closed channel for OOM is returned here as it will be
+					// non-blocking and return the correct result when read.
+					chOOM := make(chan struct{})
+					close(chOOM)
+					if err := fnHook(&c.ProcessConfig, s.Pid, chOOM); err != nil {
+						return err
 					}
 				}
-				return nil
-			}),
-		},
-	}
+			}
+			return nil
+		}))
 	return nil
 }
 

--- a/daemon/execdriver/native/template/default_template.go
+++ b/daemon/execdriver/native/template/default_template.go
@@ -92,6 +92,19 @@ func New() *configs.Config {
 	if apparmor.IsEnabled() {
 		container.AppArmorProfile = "docker-default"
 	}
+	container.Hooks = &configs.Hooks{}
+	cmd := configs.Command{
+		Path: "/usr/libexec/docker/dockerhooks",
+		Args: []string{"prestart"},
+		Env:  []string{"container=docker"},
+	}
+	container.Hooks.Prestart = append(container.Hooks.Prestart, configs.NewCommandHook(cmd))
+	cmd = configs.Command{
+		Path: "/usr/libexec/docker/dockerhooks",
+		Args: []string{"poststop"},
+		Env:  []string{"container=docker"},
+	}
+	container.Hooks.Poststop = append(container.Hooks.Poststop, configs.NewCommandHook(cmd))
 
 	return container
 }

--- a/dockerhooks/dockerhooks.go
+++ b/dockerhooks/dockerhooks.go
@@ -1,0 +1,107 @@
+// +build linux
+
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"log/syslog"
+	"os"
+	"os/exec"
+	"path"
+)
+
+const (
+	hookDirPath = "/usr/libexec/docker/hooks.d"
+)
+
+func getHooks() ([]os.FileInfo, error) {
+	// find any hooks executables
+	if _, err := os.Stat(hookDirPath); os.IsNotExist(err) {
+		return nil, nil
+	}
+	return ioutil.ReadDir(hookDirPath)
+}
+
+func prestart(hooks []os.FileInfo, stdinbytes []byte) error {
+	for _, item := range hooks {
+		if item.Mode().IsRegular() {
+			if err := run(path.Join(hookDirPath, item.Name()), stdinbytes); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func poststop(hooks []os.FileInfo, stdinbytes []byte) error {
+	for i := len(hooks) - 1; i >= 0; i-- {
+		fn := hooks[i].Name()
+		for _, item := range hooks {
+			if item.Mode().IsRegular() && fn == item.Name() {
+				if err := run(path.Join(hookDirPath, item.Name()), stdinbytes); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func run(hookfile string, incoming []byte) error {
+	cmd := exec.Command(hookfile)
+	cmd.Args = os.Args
+	cmd.Env = os.Environ()
+	log.Print("Executing docker hook: ", hookfile, cmd.Args, cmd.Env)
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+	stdinPipe.Write(incoming)
+	return nil
+}
+
+func check(err error) {
+	if err != nil {
+		log.Fatalf("ERROR: %v", err)
+	}
+}
+
+func main() {
+	var (
+		err       error
+		hooks     []os.FileInfo
+		incoming  []byte
+		logwriter *syslog.Writer
+	)
+
+	logwriter, err = syslog.New(syslog.LOG_NOTICE, "docker-hooks")
+	if err == nil {
+		log.SetOutput(logwriter)
+	}
+	log.Print("Executing dockerhook ", os.Args[0])
+
+	hooks, err = getHooks()
+	check(err)
+	if len(hooks) == 0 {
+		return
+	}
+
+	incoming, err = ioutil.ReadAll(os.Stdin)
+	check(err)
+
+	switch os.Args[0] {
+	case "prestart":
+		err := prestart(hooks, incoming)
+		check(err)
+	case "poststop":
+		err := poststop(hooks, incoming)
+		check(err)
+	default:
+		log.Fatalf("ERROR: Invalid argument %v", os.Args[0])
+	}
+}

--- a/hack/make/.dockerhooks
+++ b/hack/make/.dockerhooks
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+IAMSTATIC="true"
+source "${MAKEDIR}/.go-autogen"
+
+# dockerhooks still needs to be a static binary, even if docker is dynamic
+go build \
+	-o "$DEST/dockerhooks-$VERSION" \
+	"${BUILDFLAGS[@]}" \
+	-ldflags "
+		$LDFLAGS
+		$LDFLAGS_STATIC
+		-extldflags \"$EXTLDFLAGS_STATIC\"
+	" \
+	./dockerhooks
+
+echo "Created binary: $DEST/dockerhooks-$VERSION"
+ln -sf "dockerhooks-$VERSION" "$DEST/dockerhooks"
+
+sha1sum=
+if command -v sha1sum &> /dev/null; then
+	sha1sum=sha1sum
+elif command -v shasum &> /dev/null; then
+	# Mac OS X - why couldn't they just use the same command name and be happy?
+	sha1sum=shasum
+else
+	echo >&2 'error: cannot find sha1sum command or equivalent'
+	exit 1
+fi
+
+# sha1 our new dockerhooks to ensure separate docker and dockerhooks always run in a perfect pair compiled for one another
+export DOCKER_HOOKSSHA1=$($sha1sum "$DEST/dockerhooks-$VERSION" | cut -d' ' -f1)

--- a/hack/make/.dockerhooks
+++ b/hack/make/.dockerhooks
@@ -3,6 +3,7 @@ set -e
 
 IAMSTATIC="true"
 source "${MAKEDIR}/.go-autogen"
+LDFLAGS_STATIC=""
 
 # dockerhooks still needs to be a static binary, even if docker is dynamic
 go build \

--- a/hack/make/.dockerhooks-gccgo
+++ b/hack/make/.dockerhooks-gccgo
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+IAMSTATIC="true"
+source "${MAKEDIR}/.go-autogen"
+
+# dockerhooks still needs to be a static binary, even if docker is dynamic
+go build --compiler=gccgo \
+	-o "$DEST/dockerhooks-$VERSION" \
+	"${BUILDFLAGS[@]}" \
+	--gccgoflags "
+		-g
+		-Wl,--no-export-dynamic
+		$EXTLDFLAGS_STATIC
+		-lnetgo
+	" \
+	./dockerhooks
+
+echo "Created binary: $DEST/dockerhooks-$VERSION"
+ln -sf "dockerhooks-$VERSION" "$DEST/dockerhooks"
+
+sha1sum=
+if command -v sha1sum &> /dev/null; then
+	sha1sum=sha1sum
+else
+	echo >&2 'error: cannot find sha1sum command or equivalent'
+	exit 1
+fi
+
+# sha1 our new dockerhooks to ensure separate docker and dockerhooks always run in a perfect pair compiled for one another
+export DOCKER_HOOKSSHA1=$($sha1sum "$DEST/dockerhooks-$VERSION" | cut -d' ' -f1)

--- a/hack/make/.go-autogen
+++ b/hack/make/.go-autogen
@@ -15,6 +15,8 @@ var (
 	IAMSTATIC string = "${IAMSTATIC:-true}"
 	INITSHA1  string = "$DOCKER_INITSHA1"
 	INITPATH  string = "$DOCKER_INITPATH"
+	HOOKSSHA1  string = "$DOCKER_HOOKSSHA1"
+	HOOKSPATH  string = "$DOCKER_HOOKSPATH"
 )
 DVEOF
 

--- a/hack/make/dynbinary
+++ b/hack/make/dynbinary
@@ -2,6 +2,11 @@
 set -e
 
 if [ -z "$DOCKER_CLIENTONLY" ]; then
+	source "${MAKEDIR}/.dockerhooks"
+
+	hash_files "$DEST/dockerhooks-$VERSION"
+fi
+if [ -z "$DOCKER_CLIENTONLY" ]; then
 	source "${MAKEDIR}/.dockerinit"
 
 	hash_files "$DEST/dockerinit-$VERSION"
@@ -9,8 +14,8 @@ else
 	# DOCKER_CLIENTONLY must be truthy, so we don't need to bother with dockerinit :)
 	export DOCKER_INITSHA1=""
 fi
-# DOCKER_INITSHA1 is exported so that other bundlescripts can easily access it later without recalculating it
 
+# DOCKER_INITSHA1 is exported so that other bundlescripts can easily access it later without recalculating it
 (
 	export IAMSTATIC="false"
 	export LDFLAGS_STATIC_DOCKER=''

--- a/hack/make/dyngccgo
+++ b/hack/make/dyngccgo
@@ -2,6 +2,15 @@
 set -e
 
 if [ -z "$DOCKER_CLIENTONLY" ]; then
+	source "${MAKEDIR}/.dockerhooks-gccgo"
+
+	hash_files "$DEST/dockerhooks-$VERSION"
+else
+	# DOCKER_CLIENTONLY must be truthy, so we don't need to bother with dockerhooks :)
+	export DOCKER_HOOKSSHA1=""
+fi
+
+if [ -z "$DOCKER_CLIENTONLY" ]; then
 	source "${MAKEDIR}/.dockerinit-gccgo"
 
 	hash_files "$DEST/dockerinit-$VERSION"


### PR DESCRIPTION
Dockerhooks needs to be built without linkmode external.  Otherwise, it tries to depend on runtime/cgo.a and it segfaults when you try to run a container.

Signed-off-by: Sally O'Malley <somalley@redhat.com>