### PR TITLE
Cherry-pick to fix DockerSuite.TestCopyAndRestart

### DIFF
--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -797,7 +797,7 @@ func (s *DockerSuite) TestCopyAndRestart(c *check.C) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	dockerCmd(c, "cp", fmt.Sprintf("%s:/etc/issue", id), tmpDir)
+	dockerCmd(c, "cp", fmt.Sprintf("%s:/etc/group", id), tmpDir)
 
 	out, _ = dockerCmd(c, "start", "-a", id)
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1539,13 +1539,16 @@ func (s *DockerDaemonSuite) TestRunContainerWithBridgeNone(c *check.C) {
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
 	c.Assert(strings.Contains(out, "eth0"), check.Equals, false,
 		check.Commentf("There shouldn't be eth0 in container in bridge mode when bridge network is disabled: %s", out))
-	cmd := exec.Command("ip", "l")
+	// the extra grep and awk clean up the output of `ip` to only list the number and name of
+	// interfaces, allowing for different versions of ip (e.g. inside and outside the container) to
+	// be used while still verifying that the interface list is the exact same
+	cmd := exec.Command("sh", "-c", "ip l | grep -E '^[0-9]+:' | awk -F: ' { print $1\":\"$2 } '")
 	stdout := bytes.NewBuffer(nil)
 	cmd.Stdout = stdout
 	if err := cmd.Run(); err != nil {
 		c.Fatal("Failed to get host network interface")
 	}
-	out, err = s.d.Cmd("run", "--rm", "--net=host", "busybox", "ip", "l")
+	out, err = s.d.Cmd("run", "--rm", "--net=host", "busybox", "sh", "-c", "ip l | grep -E '^[0-9]+:' | awk -F: ' { print $1\":\"$2 } '")
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
 	c.Assert(out, check.Equals, fmt.Sprintf("%s", stdout),
 		check.Commentf("The network interfaces in container should be the same with host when --net=host when bridge network is disabled: %s", out))

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -851,9 +851,9 @@ func (s *DockerSuite) TestRunCapAddALLDropNetAdminCanDownInterface(c *check.C) {
 func (s *DockerSuite) TestRunGroupAdd(c *check.C) {
 	// Not applicable for Windows as there is no concept of --group-add
 	testRequires(c, DaemonIsLinux, NativeExecDriver)
-	out, _ := dockerCmd(c, "run", "--group-add=audio", "--group-add=dbus", "--group-add=777", "busybox", "sh", "-c", "id")
+	out, _ := dockerCmd(c, "run", "--group-add=audio", "--group-add=staff", "--group-add=777", "busybox", "sh", "-c", "id")
 
-	groupsList := "uid=0(root) gid=0(root) groups=10(wheel),29(audio),81(dbus),777"
+	groupsList := "uid=0(root) gid=0(root) groups=10(wheel),29(audio),50(staff),777"
 	if actual := strings.Trim(out, "\r\n"); actual != groupsList {
 		c.Fatalf("expected output %s received %s", groupsList, actual)
 	}
@@ -1168,13 +1168,13 @@ func (s *DockerSuite) TestRunDnsOptionsBasedOnHostResolvConf(c *check.C) {
 	}
 }
 
-// Test to see if a non-root user can resolve a DNS name and reach out to it. Also
+// Test to see if a non-root user can resolve a DNS name. Also
 // check if the container resolv.conf file has at least 0644 perm.
 func (s *DockerSuite) TestRunNonRootUserResolvName(c *check.C) {
 	// Not applicable on Windows as Windows does not support --user
 	testRequires(c, SameHostDaemon, Network, DaemonIsLinux)
 
-	dockerCmd(c, "run", "--name=testperm", "--user=default", "busybox", "ping", "-c", "1", "apt.dockerproject.org")
+	dockerCmd(c, "run", "--name=testperm", "--user=nobody", "busybox", "nslookup", "apt.dockerproject.org")
 
 	cID, err := getIDByName("testperm")
 	if err != nil {


### PR DESCRIPTION
Also requires some tests to be updated which relied on behavior
of a busybox image that wasn't actually "busybox:latest"; meaning these
tests were unable to be verified/run against a real busybox:latest image
on a daemon.

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)

(cherry picked from commit 414cfe946719a0ba811c95486d523e003d44fcc1)