### PR TITLE
Registry patches fixes

### DIFF
--- a/api/client/login.go
+++ b/api/client/login.go
@@ -23,7 +23,7 @@ import (
 //
 // Usage: docker login SERVER
 func (cli *DockerCli) CmdLogin(args ...string) error {
-	cmd := Cli.Subcmd("login", []string{"[SERVER]"}, Cli.DockerCommands["login"].Description+".\nIf no server is specified \""+registry.IndexServer+"\" is the default.", true)
+	cmd := Cli.Subcmd("login", []string{"[SERVER]"}, Cli.DockerCommands["login"].Description+".\nIf no server is specified \""+registry.IndexServerName()+"\" is the default.", true)
 	cmd.Require(flag.Max, 1)
 
 	var username, password, email string
@@ -39,7 +39,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 		cli.in = os.Stdin
 	}
 
-	serverAddress := registry.IndexServer
+	serverAddress := registry.IndexServerName()
 	if len(cmd.Args()) > 0 {
 		serverAddress = cmd.Arg(0)
 	}

--- a/api/client/logout.go
+++ b/api/client/logout.go
@@ -14,12 +14,12 @@ import (
 //
 // Usage: docker logout [SERVER]
 func (cli *DockerCli) CmdLogout(args ...string) error {
-	cmd := Cli.Subcmd("logout", []string{"[SERVER]"}, Cli.DockerCommands["logout"].Description+".\nIf no server is specified \""+registry.IndexServer+"\" is the default.", true)
+	cmd := Cli.Subcmd("logout", []string{"[SERVER]"}, Cli.DockerCommands["logout"].Description+".\nIf no server is specified \""+registry.IndexServerName()+"\" is the default.", true)
 	cmd.Require(flag.Max, 1)
 
 	cmd.ParseFlags(args, true)
 
-	serverAddress := registry.IndexServer
+	serverAddress := registry.IndexServerName()
 	if len(cmd.Args()) > 0 {
 		serverAddress = cmd.Arg(0)
 	}

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -125,8 +125,6 @@ type ImageInspect struct {
 type RemoteImageInspect struct {
 	ImageInspectBase
 	Registry string
-	Digest   string
-	Tag      string
 }
 
 // Port stores open ports info of container

--- a/graph/list_v2.go
+++ b/graph/list_v2.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution"
+	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/registry"
 	"golang.org/x/net/context"
@@ -39,6 +40,12 @@ func (p *v2TagLister) listTagsWithRepository() ([]*types.RepositoryTag, error) {
 	}
 	tags, err := manSvc.Tags()
 	if err != nil {
+		switch t := err.(type) {
+		case errcode.Errors:
+			if len(t) == 1 {
+				return nil, t[0]
+			}
+		}
 		return nil, err
 	}
 	tagList := make([]*types.RepositoryTag, len(tags))

--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -80,7 +80,9 @@ func (s *DockerDaemonSuite) SetUpTest(c *check.C) {
 
 func (s *DockerDaemonSuite) TearDownTest(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	s.d.Stop()
+	if s.d != nil {
+		s.d.Stop()
+	}
 	s.ds.TearDownTest(c)
 }
 
@@ -102,24 +104,38 @@ func (s *DockerTrustSuite) SetUpTest(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TearDownTest(c *check.C) {
-	s.reg.Close()
-	s.not.Close()
+	if s.reg != nil {
+		s.reg.Close()
+	}
+	if s.not != nil {
+		s.not.Close()
+	}
+	s.ds.TearDownTest(c)
 }
 
 type DockerRegistriesSuite struct {
 	ds   *DockerSuite
 	reg1 *testRegistryV2
 	reg2 *testRegistryV2
+	d    *Daemon
 }
 
 func (s *DockerRegistriesSuite) SetUpTest(c *check.C) {
 	s.reg1 = setupRegistryAt(c, privateRegistryURL)
 	s.reg2 = setupRegistryAt(c, privateRegistryURL2)
+	s.d = NewDaemon(c)
 }
 
 func (s *DockerRegistriesSuite) TearDownTest(c *check.C) {
-	s.reg2.Close()
-	s.reg1.Close()
+	if s.reg2 != nil {
+		s.reg2.Close()
+	}
+	if s.reg1 != nil {
+		s.reg1.Close()
+	}
+	if s.d != nil {
+		s.d.Stop()
+	}
 	s.ds.TearDownTest(c)
 }
 

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -246,24 +246,22 @@ func (s *DockerSuite) TestImagesEnsureImagesFromScratchShown(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) doTestImagesWithAdditionalRegistry(c *check.C, publicBlocked bool) {
-	d := NewDaemon(c)
+func (s *DockerDaemonSuite) doTestImagesWithAdditionalRegistry(c *check.C, publicBlocked bool) {
 	daemonArgs := []string{"--add-registry=example.com"}
 	if publicBlocked {
 		daemonArgs = append(daemonArgs, "--block-registry=public")
 	}
-	if err := d.StartWithBusybox(daemonArgs...); err != nil {
+	if err := s.d.StartWithBusybox(daemonArgs...); err != nil {
 		c.Fatalf("we should have been able to start the daemon with passing { %s } flags: %v", strings.Join(daemonArgs, ", "), err)
 	}
-	defer d.Stop()
 
-	if out, err := d.Cmd("tag", "busybox", "example.com/busybox"); err != nil {
+	if out, err := s.d.Cmd("tag", "busybox", "example.com/busybox"); err != nil {
 		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
 	}
-	if out, err := d.Cmd("tag", "busybox", "docker.io/busybox"); err != nil {
+	if out, err := s.d.Cmd("tag", "busybox", "docker.io/busybox"); err != nil {
 		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
 	}
-	if out, err := d.Cmd("tag", "busybox", "other.com/busybox"); err != nil {
+	if out, err := s.d.Cmd("tag", "busybox", "other.com/busybox"); err != nil {
 		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
 	}
 
@@ -271,7 +269,7 @@ func (s *DockerSuite) doTestImagesWithAdditionalRegistry(c *check.C, publicBlock
 	if !publicBlocked {
 		expected = append(expected, "docker.io/busybox")
 	}
-	images := d.getImages(c, "*box")
+	images := s.d.getImages(c, "*box")
 	if len(images) != len(expected) {
 		c.Fatalf("got unexpected number of images (%d), expected: %d, images: %v", len(images), len(expected), images)
 	}
@@ -282,7 +280,7 @@ func (s *DockerSuite) doTestImagesWithAdditionalRegistry(c *check.C, publicBlock
 	}
 
 	expected = []string{"docker.io/busybox", "example.com/busybox", "other.com/busybox"}
-	images = d.getImages(c, "*/*box")
+	images = s.d.getImages(c, "*/*box")
 	if len(images) != len(expected) {
 		c.Fatalf("got unexpected number of images (%d), expected: %d, images: %v", len(images), len(expected), images)
 	}
@@ -293,10 +291,10 @@ func (s *DockerSuite) doTestImagesWithAdditionalRegistry(c *check.C, publicBlock
 	}
 }
 
-func (s *DockerSuite) TestImagesWithAdditionalRegistry(c *check.C) {
+func (s *DockerDaemonSuite) TestImagesWithAdditionalRegistry(c *check.C) {
 	s.doTestImagesWithAdditionalRegistry(c, false)
 }
 
-func (s *DockerSuite) TestImagesWithPublicRegistryBlocked(c *check.C) {
+func (s *DockerDaemonSuite) TestImagesWithPublicRegistryBlocked(c *check.C) {
 	s.doTestImagesWithAdditionalRegistry(c, true)
 }

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -635,21 +635,19 @@ func (s *DockerSuite) TestPushToPublicRegistry(c *check.C) {
 	runTest(exec.Command(dockerBinary, "push", repoName), true)
 }
 
-func (s *DockerSuite) TestPushToPublicRegistryNoConfirm(c *check.C) {
-	d := NewDaemon(c)
+func (s *DockerDaemonSuite) TestPushToPublicRegistryNoConfirm(c *check.C) {
 	daemonArgs := []string{"--confirm-def-push=false"}
-	if err := d.StartWithBusybox(daemonArgs...); err != nil {
+	if err := s.d.StartWithBusybox(daemonArgs...); err != nil {
 		c.Fatalf("we should have been able to start the daemon with passing { %s } flags: %v", strings.Join(daemonArgs, ", "), err)
 	}
-	defer d.Stop()
 
 	repoName := "docker.io/user/hello-world"
-	if out, err := d.Cmd("tag", "busybox", repoName); err != nil {
+	if out, err := s.d.Cmd("tag", "busybox", repoName); err != nil {
 		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
 	}
 
 	runTest := func(name string, arg ...string) {
-		args := []string{"--host", d.sock(), name}
+		args := []string{"--host", s.d.sock(), name}
 		args = append(args, arg...)
 		c.Logf("Running %s %s %s", dockerBinary, name, strings.Join(args, " "))
 		cmd := exec.Command(dockerBinary, args...)
@@ -727,59 +725,55 @@ func (s *DockerSuite) TestPushToPublicRegistryNoConfirm(c *check.C) {
 }
 
 func (s *DockerRegistrySuite) TestPushToAdditionalRegistry(c *check.C) {
-	d := NewDaemon(c)
-	if err := d.StartWithBusybox("--add-registry=" + s.reg.url); err != nil {
+	if err := s.d.StartWithBusybox("--add-registry=" + s.reg.url); err != nil {
 		c.Fatalf("we should have been able to start the daemon with passing add-registry=%s: %v", s.reg.url, err)
 	}
-	defer d.Stop()
 
-	bbImg := d.getAndTestImageEntry(c, 1, "busybox", "")
+	bbImg := s.d.getAndTestImageEntry(c, 1, "busybox", "")
 
 	// push busybox to additional registry as "library/busybox" and remove all local images
-	if out, err := d.Cmd("tag", "busybox", "library/busybox"); err != nil {
+	if out, err := s.d.Cmd("tag", "busybox", "library/busybox"); err != nil {
 		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
 	}
-	if out, err := d.Cmd("push", "library/busybox"); err != nil {
+	if out, err := s.d.Cmd("push", "library/busybox"); err != nil {
 		c.Fatalf("failed to push image library/busybox: error %v, output %q", err, out)
 	}
 	toRemove := []string{"busybox", "library/busybox"}
-	if out, err := d.Cmd("rmi", toRemove...); err != nil {
+	if out, err := s.d.Cmd("rmi", toRemove...); err != nil {
 		c.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
 	}
-	d.getAndTestImageEntry(c, 0, "", "")
+	s.d.getAndTestImageEntry(c, 0, "", "")
 
 	// pull it from additional registry
-	if _, err := d.Cmd("pull", "library/busybox"); err != nil {
+	if _, err := s.d.Cmd("pull", "library/busybox"); err != nil {
 		c.Fatalf("we should have been able to pull library/busybox from %q: %v", s.reg.url, err)
 	}
-	bb2Img := d.getAndTestImageEntry(c, 1, s.reg.url+"/library/busybox", "")
+	bb2Img := s.d.getAndTestImageEntry(c, 1, s.reg.url+"/library/busybox", "")
 	if bb2Img.size != bbImg.size {
 		c.Fatalf("expected %s and %s to have the same size (%s != %s)", bb2Img.name, bbImg.name, bb2Img.size, bbImg.size)
 	}
 }
 
 func (s *DockerRegistrySuite) TestPushCustomTagToAdditionalRegistry(c *check.C) {
-	d := NewDaemon(c)
-	if err := d.StartWithBusybox("--add-registry=" + s.reg.url); err != nil {
+	if err := s.d.StartWithBusybox("--add-registry=" + s.reg.url); err != nil {
 		c.Fatalf("we should have been able to start the daemon with passing add-registry=%s: %v", s.reg.url, err)
 	}
-	defer d.Stop()
 
-	busyboxID := d.getAndTestImageEntry(c, 1, "busybox", "").id
+	busyboxID := s.d.getAndTestImageEntry(c, 1, "busybox", "").id
 
-	if out, err := d.Cmd("tag", "busybox", "user/busybox:1.2.3"); err != nil {
+	if out, err := s.d.Cmd("tag", "busybox", "user/busybox:1.2.3"); err != nil {
 		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
 	}
-	if out, err := d.Cmd("tag", "busybox", s.reg.url+"/user/busybox:latest"); err != nil {
+	if out, err := s.d.Cmd("tag", "busybox", s.reg.url+"/user/busybox:latest"); err != nil {
 		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
 	}
-	if out, err := d.Cmd("push", "user/busybox:1.2.3"); err != nil {
+	if out, err := s.d.Cmd("push", "user/busybox:1.2.3"); err != nil {
 		c.Fatalf("failed to push image user/busybox: error %v, output %q", err, out)
 	}
-	d.getAndTestImageEntry(c, 3, "user/busybox", busyboxID)
+	s.d.getAndTestImageEntry(c, 3, "user/busybox", busyboxID)
 	toRemove := []string{"user/busybox:1.2.3"}
-	if out, err := d.Cmd("rmi", toRemove...); err != nil {
+	if out, err := s.d.Cmd("rmi", toRemove...); err != nil {
 		c.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
 	}
-	d.getAndTestImageEntry(c, 2, s.reg.url+"/user/busybox", busyboxID)
+	s.d.getAndTestImageEntry(c, 2, s.reg.url+"/user/busybox", busyboxID)
 }

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3612,71 +3612,69 @@ func (s *DockerSuite) TestRunWrongCpusetMemsFlagValue(c *check.C) {
 }
 
 func (s *DockerRegistrySuite) TestRunWithAdditionalRegistry(c *check.C) {
-	d := NewDaemon(c)
-	if err := d.StartWithBusybox("--add-registry=" + s.reg.url); err != nil {
+	if err := s.d.StartWithBusybox("--add-registry=" + s.reg.url); err != nil {
 		c.Fatalf("we should have been able to start the daemon with passing add-registry=%s: %v", s.reg.url, err)
 	}
-	defer d.Stop()
 
-	bbImg := d.getAndTestImageEntry(c, 1, "busybox", "")
+	bbImg := s.d.getAndTestImageEntry(c, 1, "busybox", "")
 
 	// push busybox to additional registry as "library/hello-world" and remove all local images
-	if out, err := d.Cmd("tag", "busybox", s.reg.url+"/busybox"); err != nil {
+	if out, err := s.d.Cmd("tag", "busybox", s.reg.url+"/busybox"); err != nil {
 		c.Fatalf("failed to tag image busybox: error %v, output %q", err, out)
 	}
-	if out, err := d.Cmd("rmi", "busybox"); err != nil {
+	if out, err := s.d.Cmd("rmi", "busybox"); err != nil {
 		c.Fatalf("failed to remove image busybox: %v, output: %s", err, out)
 	}
-	d.getAndTestImageEntry(c, 1, s.reg.url+"/busybox", bbImg.id)
+	s.d.getAndTestImageEntry(c, 1, s.reg.url+"/busybox", bbImg.id)
 
 	// try to run fully qualified image
-	if out, err := d.Cmd("run", "-t", s.reg.url+"/busybox", "sh", "-c", "echo foo"); err != nil {
+	if out, err := s.d.Cmd("run", "-t", s.reg.url+"/busybox", "sh", "-c", "echo foo"); err != nil {
 		c.Fatalf("failed to run %s/busybox image: %v, output: %s", s.reg.url, err, out)
 	} else if strings.TrimSpace(out) != "foo" {
 		c.Fatalf("got unexpected output: %q", out)
 	}
 
 	// try to run unqualified
-	if out, err := d.Cmd("run", "-t", "busybox", "sh", "-c", "echo foo"); err != nil {
+	if out, err := s.d.Cmd("run", "-t", "busybox", "sh", "-c", "echo foo"); err != nil {
 		c.Fatalf("failed to run busybox image: %v, output: %s", err, out)
 	} else if out != "foo\r\n" {
 		c.Fatalf("got unexpected output: %q", out)
 	}
 
 	// try to run hello world from additional registry
-	if out, err := d.Cmd("run", "-t", s.reg.url+"/library/hello-world", "sh", "-c", "echo foo"); err == nil {
+	if out, err := s.d.Cmd("run", "-t", s.reg.url+"/library/hello-world", "sh", "-c", "echo foo"); err == nil {
 		c.Fatalf("running container from image %s/library/hello-world should have failed; output: %s", s.reg.url, out)
 	}
 
 	// try to run hello-world from official registry
-	if out, err := d.Cmd("run", "-t", "library/hello-world"); err != nil {
+	if out, err := s.d.Cmd("run", "-t", "library/hello-world"); err != nil {
 		c.Fatalf("failed to run library/hello-world image: %v, output: %s", err, out)
 	} else if strings.HasSuffix(strings.TrimSpace(out), "foo") {
 		c.Fatalf("got unexpected output")
 	}
-	d.getAndTestImageEntry(c, 2, "docker.io/hello-world", "")
+	s.d.getAndTestImageEntry(c, 2, "docker.io/hello-world", "")
 
 	// push busybox to additional registry as "library/hello-world" and remove all local images
-	if out, err := d.Cmd("tag", s.reg.url+"/busybox", s.reg.url+"/library/hello-world"); err != nil {
+	if out, err := s.d.Cmd("tag", s.reg.url+"/busybox", s.reg.url+"/library/hello-world"); err != nil {
 		c.Fatalf("failed to tag image %s: error %v, output %q", s.reg.url+"/busybox", err, out)
 	}
-	if out, err := d.Cmd("push", s.reg.url+"/library/hello-world"); err != nil {
+	if out, err := s.d.Cmd("push", s.reg.url+"/library/hello-world"); err != nil {
 		c.Fatalf("failed to push image %s: error %v, output %q", s.reg.url+"/library/hello-world", err, out)
 	}
-	args := []string{"-f", "hello-world", "library/hello-world"}
-	if out, err := d.Cmd("rmi", args...); err != nil {
+	args := []string{"-f", "hello-world", "library/hello-world", "busybox"}
+	if out, err := s.d.Cmd("rmi", args...); err != nil {
 		c.Fatalf("failed to remove images %v: %v, output: %s", args[1:], err, out)
 	}
-	d.getAndTestImageEntry(c, 0, "", "")
+	s.d.getAndTestImageEntry(c, 0, "", "")
 
 	// now try to run unqualified hello-world again - this time we should pull from additional registry
-	if out, err := d.Cmd("run", "-t", "library/hello-world", "sh", "-c", "echo foo"); err != nil {
+	if out, err := s.d.Cmd("run", "-t", "library/hello-world", "sh", "-c", "echo foo"); err != nil {
 		c.Fatalf("failed to run library/hello-world image: %v, output: %s", err, out)
 	} else if !strings.HasSuffix(strings.TrimSpace(out), "\nfoo") {
 		c.Fatalf("got unexpected output: %q", out)
 	}
 	// image id now differs from busybox because ids are generated again upon full pull
-	hwImg := d.getAndTestImageEntry(c, 1, s.reg.url+"/library/hello-world", "")
+	hwImg := s.d.getAndTestImageEntry(c, 1, s.reg.url+"/library/hello-world", "")
 	// therefore we need to compare size
 	if bbImg.size != hwImg.size {
 		c.Fatalf("expected %s:%s and %s:%s to have equal size (%s != %s)", hwImg.name, hwImg.tag, bbImg.name, bbImg.tag, hwImg.size, bbImg.size)

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -696,10 +696,12 @@ func deleteAllContainers() error {
 	containers, err := getAllContainers()
 	if err != nil {
 		fmt.Println(containers)
+		fmt.Fprintf(os.Stderr, "deleteAllContainers: %v\n", err)
 		return err
 	}
 
 	if err = deleteContainer(containers); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to delete containers %s: %v\n", containers, err)
 		return err
 	}
 	return nil
@@ -751,10 +753,13 @@ func deleteAllVolumes() error {
 		status, b, err := sockRequest("DELETE", "/volumes/"+v.Name, nil)
 		if err != nil {
 			errors = append(errors, err.Error())
+			fmt.Fprintf(os.Stderr, "deleteAllVolumes: %s\n", err.Error())
 			continue
 		}
 		if status != http.StatusNoContent {
-			errors = append(errors, fmt.Sprintf("error deleting volume %s: %s", v.Name, string(b)))
+			errMsg := fmt.Sprintf("error deleting volume %s: %s", v.Name, string(b))
+			fmt.Fprintf(os.Stderr, "%s\n", errMsg)
+			errors = append(errors, errMsg)
 		}
 	}
 	if len(errors) > 0 {
@@ -810,7 +815,7 @@ func init() {
 }
 
 func deleteAllImages() error {
-	out, err := exec.Command(dockerBinary, "images").CombinedOutput()
+	out, err := exec.Command(dockerBinary, "images", "--digests").CombinedOutput()
 	if err != nil {
 		return err
 	}
@@ -821,13 +826,20 @@ func deleteAllImages() error {
 			continue
 		}
 		fields := strings.Fields(l)
-		imgTag := fields[0] + ":" + fields[1]
-		if _, ok := protectedImages[imgTag]; !ok {
+		imgRef := fields[0] + ":" + fields[1]
+		if fields[1] == "<none>" {
+			if fields[2] != "<none>" {
+				imgRef = fields[0] + "@" + fields[2]
+			} else {
+				imgRef = fields[0]
+			}
+		}
+		if _, ok := protectedImages[imgRef]; !ok {
 			if fields[0] == "<none>" {
-				imgs = append(imgs, fields[2])
+				imgs = append(imgs, fields[3])
 				continue
 			}
-			imgs = append(imgs, imgTag)
+			imgs = append(imgs, imgRef)
 		}
 	}
 	if len(imgs) == 0 {
@@ -835,6 +847,7 @@ func deleteAllImages() error {
 	}
 	args := append([]string{"rmi", "-f"}, imgs...)
 	if err := exec.Command(dockerBinary, args...).Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "removing unprotected images (%s): failed with: %v\n", strings.Join(imgs, ", "), err)
 		return err
 	}
 	return nil
@@ -899,6 +912,7 @@ func deleteImages(images ...string) error {
 	exitCode, err := runCommand(rmiCmd)
 	// set error manually if not set
 	if exitCode != 0 && err == nil {
+		fmt.Fprintf(os.Stderr, "deleteImages: failed to remove images: %v\n", err)
 		err = fmt.Errorf("failed to remove image: `docker rmi` exit is non-zero")
 	}
 	return err

--- a/man/docker-daemon.8.md
+++ b/man/docker-daemon.8.md
@@ -10,10 +10,10 @@ docker-daemon - Enable daemon mode
 [**--api-cors-header**=[=*API-CORS-HEADER*]]
 [**-b**|**--bridge**[=*BRIDGE*]]
 [**--bip**[=*BIP*]]
+[**--block-registry**[=*[]*]]
 [**--cluster-store**[=*[]*]]
 [**--cluster-advertise**[=*[]*]]
 [**--cluster-store-opt**[=*map[]*]]
-[**--block-registry**[=*[]*]]
 [**-D**|**--debug**[=*false*]]
 [**--default-gateway**[=*DEFAULT-GATEWAY*]]
 [**--default-gateway-v6**[=*DEFAULT-GATEWAY-V6*]]
@@ -82,6 +82,9 @@ format.
 **--bip**=""
   Use the provided CIDR notation address for the dynamically created bridge (docker0); Mutually exclusive of \-b
 
+**--block-registry**=[]
+  **EXPERIMENTAL** Prevent Docker daemon from contacting specified registries. There are two special keywords recognized. The first is "public" and represents public Docker registry. The second is "all" which causes all registries but those added with **--add-registry** flag to be blocked.
+
 **--cluster-store**=""
   URL of the distributed storage backend
 
@@ -92,9 +95,6 @@ format.
 
 **--cluster-store-opt**=""
   Specifies options for the Key/Value store.
-
-**--block-registry**=[]
-  **EXPERIMENTAL** Prevent Docker daemon from contacting specified registries. There are two special keywords recognized. The first is "public" and represents public Docker registry. The second is "all" which causes all registries but those added with **--add-registry** flag to be blocked.
 
 **-D**, **--debug**=*true*|*false*
   Enable debug mode. Default is false.

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -36,7 +36,7 @@ func loginV1(authConfig *cliconfig.AuthConfig, registryEndpoint *Endpoint) (stri
 		return "", fmt.Errorf("Server Error: Server Address not set.")
 	}
 
-	loginAgainstOfficialIndex := serverAddress == IndexServer
+	loginAgainstOfficialIndex := serverAddress == IndexServerName()
 
 	// to avoid sending the server address to the server it should be removed before being marshalled
 	authCopy := *authConfig


### PR DESCRIPTION
Refactored tests.
- Use suite's daemon.
- Fixed deletion of temporary images in teardowns.

Return 404 from tag list handler when repository doesn't exist.

Signed-off-by: Michal Minar <miminar@redhat.com>